### PR TITLE
feat: allow wildcard characters in the /seed endpoint

### DIFF
--- a/server/src/models_games.go
+++ b/server/src/models_games.go
@@ -321,8 +321,12 @@ func (*Games) GetGameIDsUser(userID int, offset int, amount int) ([]int, error) 
 	return gameIDs, nil
 }
 
-func (*Games) GetGameIDsSeed(seed string) ([]int, error) {
+const PageSize = 1000
+
+func (*Games) GetGameIDsSeed(seed string, page uint) ([]int, error) {
 	gameIDs := make([]int, 0)
+    record_number_lower_bound := page * PageSize
+    record_number_upper_bound := (page + 1) * PageSize
 
 	// Neither % nor _ chars are permitted in seed names, so the change in comparator
 	// from '=' to 'LIKE' should not affect any previously working queries.


### PR DESCRIPTION
By simply using the SQL LIKE comparator in the backend, the user can request results across multiple seeds, through use of wildcard metacharacters.

The use case driving this feature addition is the NoVarathon initiative, where we aim to collect results for seeded no variant games in close to real time. The seed name will follow a pattern, and we want results for all seeds matching that pattern.