### PR TITLE
fix regexp

### DIFF
--- a/server/src/chat.go
+++ b/server/src/chat.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	mentionRegExp = regexp.MustCompile(`&lt;@&!*(\d+?)&gt;`)
+	mentionRegExp = regexp.MustCompile(`&lt;@&*!*(\d+?)&gt;`)
 	channelRegExp = regexp.MustCompile(`&lt;#(\d+?)&gt;`)
 )
 
@@ -79,9 +79,9 @@ func chatServerSendPM(s *Session, msg string, room string) {
 }
 
 func chatFillMentions(msg string) string {
-	if discord == nil {
-		return msg
-	}
+	// if discord == nil {
+	// 	return msg
+	// }
 
 	// Discord mentions are in the form of "<@12345678901234567>"
 	// By the time the message gets here, it will be sanitized to "&lt;@12345678901234567&gt;"

--- a/server/src/chat.go
+++ b/server/src/chat.go
@@ -79,9 +79,9 @@ func chatServerSendPM(s *Session, msg string, room string) {
 }
 
 func chatFillMentions(msg string) string {
-	// if discord == nil {
-	// 	return msg
-	// }
+	if discord == nil {
+		return msg
+	}
 
 	// Discord mentions are in the form of "<@12345678901234567>"
 	// By the time the message gets here, it will be sanitized to "&lt;@12345678901234567&gt;"

--- a/server/src/chat.go
+++ b/server/src/chat.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	mentionRegExp = regexp.MustCompile(`&lt;@!*(\d+?)&gt;`)
+	mentionRegExp = regexp.MustCompile(`&lt;@&!*(\d+?)&gt;`)
 	channelRegExp = regexp.MustCompile(`&lt;#(\d+?)&gt;`)
 )
 


### PR DESCRIPTION
Closes #2059 

Cannot test (but [code](https://github.com/Hanabi-Live/hanabi-live/blob/bcbe24fe6ef18f1591ffd9aaab68980e3f7bed5b/server/src/chat.go#L93) now fetches the correct user id)

(based on issue screenshot)