### PR TITLE
Close modals before warning

### DIFF
--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -19,13 +19,15 @@ interface WarningData {
 }
 commands.set("warning", (data: WarningData) => {
   console.warn(data.warning);
-  modals.showWarning(data.warning);
-
-  // Re-activate some lobby elements
-  $("#nav-buttons-lobby-create-game").removeClass("disabled");
-  if (globals.currentScreen === Screen.PreGame) {
-    pregame.toggleStartGameButton();
-  }
+  modals.closeModals(true);
+  setTimeout(() => {
+    modals.showWarning(data.warning);
+    // Re-activate some lobby elements
+    $("#nav-buttons-lobby-create-game").removeClass("disabled");
+    if (globals.currentScreen === Screen.PreGame) {
+      pregame.toggleStartGameButton();
+    }
+  }, 100);
 });
 
 interface ErrorData {


### PR DESCRIPTION
When `gameID` does not exist in the database, make sure the modal is shown.