### PR TITLE
Add optional limits to history-full API

### DIFF
--- a/server/src/api_games.go
+++ b/server/src/api_games.go
@@ -96,9 +96,12 @@ func apiFullDataHistory(c *gin.Context) {
 		playerIDs = v1
 	}
 
+	// look for limiting parameters
+	idStart, idEnd := apiGetLimits(c)
+
 	// Get the game IDs for this player (or set of players)
 	var gameIDs []int
-	if v, err := models.Games.GetFullGameIDsMultiUser(playerIDs); err != nil {
+	if v, err := models.Games.GetFullGameIDsMultiUser(playerIDs, idStart, idEnd); err != nil {
 		c.JSON(http.StatusBadRequest, APIGamesAnswer{})
 		return
 	} else {

--- a/server/src/api_misc.go
+++ b/server/src/api_misc.go
@@ -105,6 +105,23 @@ func apiGetFilters(c *gin.Context, columns []string, initialFilter APIColumnDesc
 	return filters
 }
 
+// Searches query vars for optional params start, end
+func apiGetLimits(c *gin.Context) (idStart, idEnd *int) {
+	var start, end *int
+	if v, err := strconv.Atoi(c.Query("start")); err == nil {
+		start = &v
+	} else {
+		start = nil
+	}
+
+	if v, err := strconv.Atoi(c.Query("end")); err == nil {
+		end = &v
+	} else {
+		end = nil
+	}
+	return start, end
+}
+
 // Builds an SQL subquery
 // Returns the WHERE part, the ORDER BY part and the args
 func apiBuildSubquery(params APIQueryVars) (string, string, string, []interface{}) {

--- a/server/src/models_games.go
+++ b/server/src/models_games.go
@@ -495,7 +495,7 @@ func (*Games) GetGameIDsMultiUser(userIDs []int, wQuery, orderBy, limit string, 
 	return gameIDs, nil
 }
 
-func (*Games) GetFullGameIDsMultiUser(userIDs []int) ([]int, error) {
+func (*Games) GetFullGameIDsMultiUser(userIDs []int, idStart *int, idEnd *int) ([]int, error) {
 	gameIDs := make([]int, 0)
 
 	// First, validate that all of the user IDs are unique
@@ -516,6 +516,14 @@ func (*Games) GetFullGameIDsMultiUser(userIDs []int) ([]int, error) {
 		SQLString += "JOIN game_participants AS player" + strconv.Itoa(id) + "_games "
 		SQLString += "ON games.id = player" + strconv.Itoa(id) + "_games.game_id "
 		SQLString += "AND player" + strconv.Itoa(id) + "_games.user_id = " + strconv.Itoa(id) + " "
+	}
+
+	if idStart != nil {
+		SQLString += "AND games.id >= " + strconv.Itoa(*idStart) + " "
+	}
+
+	if idEnd != nil {
+		SQLString += "AND games.id <= " + strconv.Itoa(*idEnd) + " "
 	}
 
 	var rows pgx.Rows


### PR DESCRIPTION
New optional query parameters `start` and `end` for history-full API.

Example:

`hanab.live/api/v1/history-full/Alice?start=50&end=100` returns the games with IDs between 50 and 100 (including).

Both parameters are optional.