### PR TITLE
Table spectators, owners and beautiful eyes

### DIFF
--- a/packages/client/src/lobby/lobbyCommands.ts
+++ b/packages/client/src/lobby/lobbyCommands.ts
@@ -1,6 +1,7 @@
 // We will receive WebSocket messages / commands from the server that tell us to do things
 
 import * as gameMain from "../game/main";
+import Spectator from "../game/types/Spectator";
 import * as spectatorsView from "../game/ui/reactive/view/spectatorsView";
 import globals from "../globals";
 import * as sentry from "../sentry";
@@ -222,6 +223,16 @@ commands.set("tableStart", (data: TableStartData) => {
     pregame.hide();
   }
   gameMain.show();
+});
+
+interface SpectatorsData {
+  tableID: number;
+  spectators: Spectator[];
+}
+commands.set("pregameSpectators", (data: SpectatorsData) => {
+  globals.tableID = data.tableID;
+
+  pregame.drawSpectators(globals.tableID);
 });
 
 // Received by the client when a user connects or has a new status

--- a/packages/client/src/lobby/nav.ts
+++ b/packages/client/src/lobby/nav.ts
@@ -177,9 +177,22 @@ export function init(): void {
 
   // The "Leave Game" button
   $("#nav-buttons-pregame-leave").on("click", () => {
-    globals.conn!.send("tableLeave", {
-      tableID: globals.tableID,
-    });
+    // "Leave Game" and "Return to Lobby" are the same for spectators
+    const table = globals.tableMap.get(globals.tableID);
+    if (table === undefined) {
+      return;
+    }
+    if (table.spectators.includes(globals.username)) {
+      pregame.hide();
+      globals.conn!.send("tableUnattend", {
+        tableID: globals.tableID,
+      });
+      globals.tableID = -1;
+    } else {
+      globals.conn!.send("tableLeave", {
+        tableID: globals.tableID,
+      });
+    }
   });
 
   // The "Show History of Friends" button (from the "History" screen)

--- a/packages/client/src/lobby/pregame.ts
+++ b/packages/client/src/lobby/pregame.ts
@@ -456,6 +456,24 @@ function drawPlayerBox(i: number) {
   tooltips.create(`#lobby-pregame-player-${i + 1}-scores-icon`);
 }
 
+export function drawSpectators(tableID: number): void {
+  if (globals.game === null) {
+    return;
+  }
+
+  const list = $("#lobby-pregame-spectators");
+  list.empty();
+  const table = globals.tableMap.get(tableID);
+  if (table === undefined) {
+    return;
+  }
+
+  for (const spectator of table.spectators) {
+    const item = `<li>&bull; ${spectator}</li>`;
+    list.append(item);
+  }
+}
+
 export function toggleStartGameButton(): void {
   // Enable or disable the "Start Game" button.
   // "Start Game" enabled if game owner and enough players

--- a/packages/client/src/lobby/tablesDraw.ts
+++ b/packages/client/src/lobby/tablesDraw.ts
@@ -177,14 +177,20 @@ export default function tablesDraw(): void {
       }
     }
     spectatorsString = spectatorsArray.join(", ");
-    $("<td>")
-      .html(spectatorsString)
-      .addClass("lobbySpectators")
-      .on("click", (evt) => {
-        evt.stopPropagation();
-        tableSpectate(table);
-      })
-      .appendTo(row);
+    // Change click behavior on the spectators cell
+    if (table.joined) {
+      $("<td>").html(spectatorsString).appendTo(row);
+    } else {
+      // Can also join as a spectator
+      $("<td>")
+        .html(spectatorsString)
+        .addClass("lobbySpectators")
+        .on("click", (evt) => {
+          evt.stopPropagation();
+          tableSpectate(table);
+        })
+        .appendTo(row);
+    }
 
     // There is a keyboard shortcut to join the first table available
     // Add a class to the first relevant row to facilitate this

--- a/packages/client/src/lobby/tablesDraw.ts
+++ b/packages/client/src/lobby/tablesDraw.ts
@@ -167,21 +167,24 @@ export default function tablesDraw(): void {
     $("<td>").html(playersString).appendTo(row);
 
     // Column 7 - Spectators
-    let spectatorsString: string;
-    if (table.spectators.length === 0) {
-      spectatorsString = "-";
-    } else {
-      const spectatorsArray: string[] = [];
-      for (const spectator of table.spectators) {
-        if (globals.friends.includes(spectator)) {
-          spectatorsArray.push(`<span class="friend">${spectator}</span>`);
-        } else {
-          spectatorsArray.push(spectator);
-        }
+    let spectatorsString = "";
+    const spectatorsArray: string[] = [];
+    for (const spectator of table.spectators) {
+      if (globals.friends.includes(spectator)) {
+        spectatorsArray.push(`<span class="friend">${spectator}</span>`);
+      } else {
+        spectatorsArray.push(spectator);
       }
-      spectatorsString = spectatorsArray.join(", ");
     }
-    $("<td>").html(spectatorsString).appendTo(row);
+    spectatorsString = spectatorsArray.join(", ");
+    $("<td>")
+      .html(spectatorsString)
+      .addClass("lobbySpectators")
+      .on("click", (evt) => {
+        evt.stopPropagation();
+        tableSpectate(table);
+      })
+      .appendTo(row);
 
     // There is a keyboard shortcut to join the first table available
     // Add a class to the first relevant row to facilitate this

--- a/packages/client/src/lobby/tablesDraw.ts
+++ b/packages/client/src/lobby/tablesDraw.ts
@@ -116,13 +116,15 @@ export default function tablesDraw(): void {
     $("<td>").html(name).appendTo(row);
 
     // Column 2 - # of Players
-    $("<td>")
-      .html(
-        table.running || table.sharedReplay
-          ? table.numPlayers.toString()
-          : `${table.numPlayers.toString()} / ${table.maxPlayers.toString()}`,
-      )
-      .appendTo(row);
+    const tdCell = $("<td>").html(
+      table.running || table.sharedReplay
+        ? table.numPlayers.toString()
+        : `${table.numPlayers.toString()} / ${table.maxPlayers.toString()}`,
+    );
+    if (table.numPlayers === table.maxPlayers) {
+      row.addClass("full");
+    }
+    tdCell.appendTo(row);
 
     // Column 3 - Variant
     $("<td>").html(table.variant).appendTo(row);

--- a/packages/client/src/lobby/types/Table.ts
+++ b/packages/client/src/lobby/types/Table.ts
@@ -14,6 +14,6 @@ export default interface Table {
   sharedReplay: boolean;
   progress: number;
   players: string[]; // e.g. ['Alice', 'Bob']
-  spectators: string;
+  spectators: string[];
   maxPlayers: number;
 }

--- a/public/css/hanabi.css
+++ b/public/css/hanabi.css
@@ -424,27 +424,43 @@ table td {
 
 .lobby-games-table-joined:hover {
   background-color: #e0e0ff !important;
-  cursor: url("/public/img/hover-cursors/play.png") 28 12.5, pointer;
+}
+.lobby-games-table-joined:hover {
+  /* rejoin */
+  cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='23.713' height='23.713' viewBox='0 0 6.274 6.274'><g stroke='%232e3436' stroke-linecap='round' stroke-linejoin='round' stroke-width='.1' transform='translate(-88.655 -55.22)'><circle cx='91.792' cy='58.356' r='3.087' fill='%23e6cf04'/><path fill='%23fff' d='m93.809 58.356-1.583.914-1.583.913v-3.655l1.583.914z'/></g></svg>"),
+    pointer;
 }
 .lobby-games-table-unstarted:hover {
   background-color: #ffffe1 !important;
-  cursor: url("/public/img/hover-cursors/join.png") 28 12.5, pointer;
 }
 .lobby-games-table-unstarted-password:hover {
   background-color: #ffd5d5 !important;
-  cursor: url("/public/img/hover-cursors/join.png") 28 12.5, pointer;
 }
-.lobby-games-table-started:hover {
-  background-color: #cdffdd !important;
-  cursor: url("/public/img/hover-cursors/view.png") 28 12.5, pointer;
-}
-.lobby-games-table-replay:hover {
-  background-color: #ffe1ff !important;
-  cursor: url("/public/img/hover-cursors/view.png") 28 12.5, pointer;
+.lobby-games-table-unstarted:hover,
+.lobby-games-table-unstarted-password:hover {
+  /* join */
+  cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='23.096' height='18.894' viewBox='0 0 6.111 4.999'><g fill='%23aad400' stroke='%23000' stroke-linejoin='round' stroke-width='.1'><path d='M.051 1.628H1.91V.06l2.444 2.444L1.91 4.949V3.382H.05z'/><path d='M3.863.05h1.52c.314 0 .678.34.678.654v3.31c0 .33-.347.724-.678.724h-1.52v-.725h1.52V.703h-1.52z'/></g></svg>"),
+    pointer;
 }
 .lobby-games-table-unstarted.full:hover,
 .lobby-games-table-unstarted-password.full:hover {
-  cursor: url("/public/img/hover-cursors/forbid.png") 28 12.5, pointer;
+  /* full */
+  cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='23.713' height='23.713' viewBox='0 0 6.274 6.274'><g stroke='%23000' stroke-linecap='round' stroke-width='.1' transform='translate(-105.376 -101.255)'><circle cx='108.513' cy='104.392' r='2.778' fill='%23fff'/><path fill='%238b0000' d='M108.513 101.305a3.087 3.087 0 0 0-3.087 3.087 3.087 3.087 0 0 0 3.087 3.087 3.087 3.087 0 0 0 3.087-3.087 3.087 3.087 0 0 0-3.087-3.087zm0 .644a2.443 2.443 0 0 1 2.443 2.443 2.443 2.443 0 0 1-.428 1.381l-3.581-3.256a2.443 2.443 0 0 1 1.566-.568zm-2.015 1.061 3.582 3.256a2.443 2.443 0 0 1-1.567.57 2.443 2.443 0 0 1-2.444-2.444 2.443 2.443 0 0 1 .43-1.382z'/></g></svg>"),
+    pointer;
+}
+.lobby-games-table-started:hover {
+  background-color: #cdffdd !important;
+}
+.lobby-games-table-replay:hover {
+  background-color: #ffe1ff !important;
+}
+.lobby-games-table-started,
+.lobby-games-table-replay,
+.lobby-games-table-unstarted .lobbySpectators,
+.lobby-games-table-unstarted-password .lobbySpectators {
+  /* eyes */
+  cursor: url("data:image/svg+xml;utf8,<svg width='28.343' height='25.001' viewBox='0 0 7.499 6.615' xmlns='http://www.w3.org/2000/svg'><g stroke-dasharray='.265 .265' stroke-width='.265'><g transform='translate(-10.083 -12.47) scale(.17804)'><rect x='56.63' y='70.043' width='21.116' height='37.155' rx='11' ry='11'/><rect x='59.258' y='72.769' width='15.881' height='31.881' rx='8' ry='8' fill='%23fff'/><circle cx='65.925' cy='92.591' r='6.667' fill='%23060'/><circle cx='67.821' cy='90.635' r='2.044' fill='%23fff'/></g><g transform='translate(-6.343 -12.47) scale(.17804)'><rect x='56.63' y='70.043' width='21.116' height='37.155' rx='11' ry='11'/><rect x='59.258' y='72.769' width='15.881' height='31.881' rx='8' ry='8' fill='%23fff'/><circle cx='65.925' cy='92.591' r='6.667' fill='%23060'/><circle cx='67.821' cy='90.635' r='2.044' fill='%23fff'/></g></g></svg>"),
+    pointer;
 }
 
 /*

--- a/public/css/hanabi.css
+++ b/public/css/hanabi.css
@@ -547,10 +547,16 @@ table td {
   margin-bottom: 0;
 }
 
-#lobby-pregame-options {
+#lobby-pregame-options,
+#lobby-pregame-spectators {
   padding-left: 1em;
   list-style-type: none;
   padding: 0;
+  margin: 0;
+}
+
+#lobby-pregame-options-title {
+  font-weight: 400;
 }
 
 #lobby-pregame-options li {

--- a/public/img/hover-cursors/icons.svg
+++ b/public/img/hover-cursors/icons.svg
@@ -1,218 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="44.166668mm"
-   height="18.176191mm"
-   viewBox="0 0 44.166668 18.176191"
-   version="1.1"
-   id="svg8"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
-   sodipodi:docname="icons.svg"
-   inkscape:export-filename="C:\Users\Takis\Desktop\icons\all_icons.png"
-   inkscape:export-xdpi="300"
-   inkscape:export-ydpi="300">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="85.706492"
-     inkscape:cy="67.102478"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     inkscape:document-rotation="0"
-     showgrid="false"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:window-width="2382"
-     inkscape:window-height="1368"
-     inkscape:window-x="146"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-85.337487,-49.252526)">
-    <rect
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#555753;stroke-width:0.0530983;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1081"
-       width="44.113571"
-       height="18.123093"
-       x="85.364037"
-       y="49.279076"
-       inkscape:export-xdpi="300.44797"
-       inkscape:export-ydpi="300.44797" />
-    <g
-       id="g904"
-       inkscape:export-xdpi="96"
-       inkscape:export-ydpi="96">
-      <rect
-         style="fill:#ad7fa8;fill-opacity:1;stroke:none;stroke-width:0.0986013;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;opacity:0"
-         id="rect880"
-         width="7.4083333"
-         height="6.6145835"
-         x="107.85651"
-         y="55.04845" />
-      <g
-         id="g880"
-         transform="translate(3.0476738,-46.036309)"
-         inkscape:export-xdpi="97.158249"
-         inkscape:export-ydpi="97.158249"
-         style="stroke:#000000;stroke-width:0.1;stroke-miterlimit:4;stroke-dasharray:none">
-        <circle
-           style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
-           id="path876"
-           cx="108.51301"
-           cy="104.39205"
-           r="2.778125" />
-        <path
-           id="path859"
-           style="fill:#8b0000;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
-           d="m 108.51275,101.3049 a 3.0869651,3.0869651 0 0 0 -3.08663,3.08715 3.0869651,3.0869651 0 0 0 3.08663,3.08715 3.0869651,3.0869651 0 0 0 3.08715,-3.08715 3.0869651,3.0869651 0 0 0 -3.08715,-3.08715 z m 0,0.64389 a 2.44326,2.44326 0 0 1 2.44327,2.44326 2.44326,2.44326 0 0 1 -0.42788,1.38131 l -3.58118,-3.25613 a 2.44326,2.44326 0 0 1 1.56579,-0.56844 z m -2.01434,1.06144 3.58169,3.25613 a 2.44326,2.44326 0 0 1 -1.56735,0.56895 2.44326,2.44326 0 0 1 -2.44326,-2.44326 2.44326,2.44326 0 0 1 0.42892,-1.38182 z" />
-      </g>
-    </g>
-    <g
-       id="g898"
-       inkscape:export-xdpi="96"
-       inkscape:export-ydpi="96">
-      <rect
-         style="fill:#ad7fa8;fill-opacity:1;stroke:none;stroke-width:0.0986013;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;opacity:0"
-         id="rect884"
-         width="7.4083333"
-         height="6.6145835"
-         x="97.972229"
-         y="55.04845" />
-      <g
-         id="g950"
-         transform="translate(46.952965,-3.9272433)"
-         inkscape:export-xdpi="96.531815"
-         inkscape:export-ydpi="96.531815"
-         style="fill:#aad400;stroke:#000000;stroke-width:0.1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-        <path
-           style="fill:#aad400;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 51.718323,61.41186 h 1.859195 v -1.56687 l 2.443846,2.443847 -2.443846,2.443848 v -1.566876 h -1.859195 z"
-           id="path924" />
-        <path
-           style="fill:#aad400;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 55.530252,59.83329 h 1.520097 c 0.314241,0 0.678196,0.340568 0.678196,0.654809 0,0 0,2.261519 0,3.30913 0,0.330914 -0.347282,0.724972 -0.678196,0.724972 -0.461203,0 -1.520097,0 -1.520097,0 v -0.724972 h 1.520097 v -3.30913 h -1.520097 z"
-           id="path946"
-           sodipodi:nodetypes="csssscccccc" />
-      </g>
-    </g>
-    <g
-       id="g913"
-       inkscape:export-xdpi="96"
-       inkscape:export-ydpi="96">
-      <rect
-         style="fill:#ad7fa8;fill-opacity:1;stroke:none;stroke-width:0.0986013;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;opacity:0"
-         id="rect882"
-         width="7.4083333"
-         height="6.6145835"
-         x="118.22868"
-         y="55.04845" />
-      <g
-         id="g1079"
-         inkscape:export-xdpi="96"
-         inkscape:export-ydpi="96"
-         transform="translate(94.841407,12.847411)">
-        <path
-           style="fill:#2e3436;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 23.548449,45.414794 c 2.361993,-2.875867 4.723987,-3.078385 7.085983,0 v 0.239707 c -2.361996,3.005839 -4.72399,2.808094 -7.085983,0 z"
-           id="path1060"
-           sodipodi:nodetypes="ccccc" />
-        <g
-           id="g1052"
-           transform="matrix(1.1849853,0,0,1.1849853,-20.256414,-31.838816)">
-          <circle
-             style="opacity:1;fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.103272;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="path1043"
-             cx="39.963894"
-             cy="65.220863"
-             r="1.6090804" />
-          <circle
-             style="opacity:1;fill:#3465a4;fill-opacity:1;stroke:none;stroke-width:0.242186;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="path1045"
-             cx="39.963894"
-             cy="65.220863"
-             r="1.2035558" />
-          <circle
-             style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0804216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="circle1047"
-             cx="39.42894"
-             cy="64.697601"
-             r="0.39965919" />
-        </g>
-      </g>
-    </g>
-    <g
-       id="g892"
-       inkscape:export-xdpi="96"
-       inkscape:export-ydpi="96">
-      <rect
-         style="fill:#ad7fa8;fill-opacity:1;stroke:none;stroke-width:0.0986013;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;opacity:0"
-         id="rect886"
-         width="7.4083333"
-         height="6.6145835"
-         x="88.087868"
-         y="55.048447" />
-      <g
-         id="g878"
-         inkscape:export-xdpi="97.157791"
-         inkscape:export-ydpi="97.157791">
-        <ellipse
-           style="fill:#e6cf04;fill-opacity:1;stroke:#2e3436;stroke-width:0.100003;stroke-linecap:round;stroke-linejoin:round"
-           id="path858"
-           cx="91.792038"
-           cy="58.35574"
-           rx="3.0869613"
-           ry="3.087163"
-           inkscape:export-xdpi="97.157791"
-           inkscape:export-ydpi="97.157791" />
-        <path
-           sodipodi:type="star"
-           style="fill:#ffffff;stroke:#2e3436;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-           id="path860"
-           sodipodi:sides="3"
-           sodipodi:cx="91.698512"
-           sodipodi:cy="58.355741"
-           sodipodi:r1="2.1105094"
-           sodipodi:r2="1.0552547"
-           sodipodi:arg1="0"
-           sodipodi:arg2="1.0471976"
-           inkscape:flatsided="false"
-           inkscape:rounded="0"
-           inkscape:randomized="0"
-           inkscape:transform-center-x="-0.5276275"
-           d="m 93.809019,58.35574 -1.582882,0.913877 -1.582882,0.913877 V 58.35574 56.527985 l 1.582882,0.913877 z" />
-      </g>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="166.929" height="68.697" viewBox="0 0 44.167 18.176">
+  <!-- rejoin -->
+  <g stroke="#2e3436" stroke-linecap="round" stroke-linejoin="round" stroke-width=".1" transform="translate(-85.337 -49.253)">
+    <circle cx="91.792" cy="58.356" r="3.087" fill="#e6cf04"/>
+    <path fill="#fff" d="m93.809 58.356-1.583.914-1.583.913v-3.655l1.583.914z"/>
+  </g>
+  <!-- join -->
+  <g fill="#aad400" stroke="#000" stroke-linejoin="round" stroke-width=".1">
+    <path d="M13.334 8.232h1.859V6.665l2.444 2.444-2.444 2.444V9.986h-1.86z"/>
+    <path d="M17.146 6.654h1.52c.314 0 .678.34.678.654v3.31c0 .33-.347.724-.678.724h-1.52v-.725h1.52V7.308h-1.52z"/>
+  </g>
+  <!-- forbig -->
+  <g stroke="#000" stroke-linecap="round" stroke-width=".1" transform="translate(-82.29 -95.289)">
+    <circle cx="108.513" cy="104.392" r="2.778" fill="#fff"/>
+    <path fill="#8b0000" d="M108.513 101.305a3.087 3.087 0 0 0-3.087 3.087 3.087 3.087 0 0 0 3.087 3.087 3.087 3.087 0 0 0 3.087-3.087 3.087 3.087 0 0 0-3.087-3.087zm0 .644a2.443 2.443 0 0 1 2.443 2.443 2.443 2.443 0 0 1-.428 1.381l-3.581-3.256a2.443 2.443 0 0 1 1.566-.568zm-2.015 1.061 3.582 3.256a2.443 2.443 0 0 1-1.567.57 2.443 2.443 0 0 1-2.444-2.444 2.443 2.443 0 0 1 .43-1.382z"/>
+  </g>
+  <g transform="translate(22.753 -6.675) scale(.17804)">
+    <rect width="21.116" height="37.155" x="56.63" y="70.043" rx="11" ry="11"/>
+    <rect width="15.881" height="31.881" x="59.258" y="72.769" fill="#fff" rx="8" ry="8"/>
+    <circle cx="65.925" cy="92.591" r="6.667" fill="#060"/>
+    <circle cx="67.821" cy="90.635" r="2.044" fill="#fff"/>
+  </g>
+  <!-- spectate -->
+  <g transform="translate(26.49 -6.675) scale(.17804)">
+    <rect width="21.116" height="37.155" x="56.63" y="70.043" rx="11" ry="11"/>
+    <rect width="15.881" height="31.881" x="59.258" y="72.769" fill="#fff" rx="8" ry="8"/>
+    <circle cx="65.925" cy="92.591" r="6.667" fill="#060"/>
+    <circle cx="67.821" cy="90.635" r="2.044" fill="#fff"/>
   </g>
 </svg>

--- a/server/src/command_table_create.go
+++ b/server/src/command_table_create.go
@@ -200,7 +200,7 @@ func tableCreate(ctx context.Context, s *Session, d *CommandData, data *SpecialG
 	// (a "table" message will be sent in the "commandTableJoin" function below)
 
 	// Log a chat message so that future players can see a timestamp of when the table was created
-	msg := s.Username + " created the table."
+	msg := "<strong>" + s.Username + "</strong> created the table."
 	chatServerSend(ctx, msg, t.GetRoomName(), true)
 
 	// If the server is shutting down / restarting soon, warn the players

--- a/server/src/command_table_join.go
+++ b/server/src/command_table_join.go
@@ -151,6 +151,15 @@ func tableJoin(ctx context.Context, s *Session, d *CommandData, t *Table) {
 	chatSendPastFromTable(s, t)
 	t.ChatRead[p.UserID] = len(t.Chat)
 
+	// Announce the new player (unless this is the first one)
+	if len(t.Players) > 1 {
+		msg := s.Username + " joined the game."
+		chatServerSend(ctx, msg, t.GetRoomName(), true)
+	}
+
+	// Send them the list of spectators
+	t.NotifySpectators()
+
 	// Send them messages for people typing, if any
 	for _, p := range t.Players {
 		if p.Typing {

--- a/server/src/command_table_leave.go
+++ b/server/src/command_table_leave.go
@@ -61,6 +61,9 @@ func tableLeave(ctx context.Context, s *Session, d *CommandData, t *Table, playe
 	tables.DeletePlaying(s.UserID, t.ID) // Keep track of user to table relationships
 
 	notifyAllTable(t)
+	// Announce the departure of the player
+	msg := s.Username + " left the game."
+	chatServerSend(ctx, msg, t.GetRoomName(), true)
 	t.NotifyPlayerChange()
 
 	// Set their status

--- a/server/src/command_table_start.go
+++ b/server/src/command_table_start.go
@@ -271,6 +271,9 @@ func tableStart(ctx context.Context, s *Session, d *CommandData, t *Table) {
 			p.Session.NotifyTableStart(t)
 		}
 	}
+	for _, s := range t.Spectators {
+		s.Session.NotifyTableStart(t)
+	}
 
 	// If we are emulating actions on a replay, we do not have to tell anyone about the table yet
 	if !t.ExtraOptions.NoWriteToDatabase {

--- a/server/src/command_table_unattend.go
+++ b/server/src/command_table_unattend.go
@@ -102,7 +102,12 @@ func tableUnattendSpectator(ctx context.Context, s *Session, d *CommandData, t *
 		return
 	}
 
-	notifyAllTable(t)    // Update the spectator list for the row in the lobby
+	notifyAllTable(t) // Update the spectator list for the row in the lobby
+	if t.Game == nil {
+		// This is a pregame, announce the departure of the spectator
+		msg := s.Username + " left the table."
+		chatServerSend(ctx, msg, t.GetRoomName(), true)
+	}
 	t.NotifySpectators() // Update the in-game spectator list
 
 	if !t.Replay && len(cardOrderList) > 0 {

--- a/server/src/session_notify.go
+++ b/server/src/session_notify.go
@@ -167,17 +167,6 @@ func (s *Session) NotifyTableStart(t *Table) {
 	})
 }
 
-func (s *Session) NotifyTableJoinedAsSpectator(t *Table) {
-	type TableJoinAsSpectator struct {
-		TableID uint64 `json:"tableID"`
-		Replay  bool   `json:"replay"`
-	}
-	s.Emit("tableJoinedAsSpectator", &TableJoinAsSpectator{
-		TableID: t.ID,
-		Replay:  t.Replay,
-	})
-}
-
 func (s *Session) NotifyShutdown() {
 	type ShutdownMessage struct {
 		ShuttingDown         bool      `json:"shuttingDown"`
@@ -297,7 +286,13 @@ func (s *Session) NotifySpectators(t *Table) {
 		TableID    uint64       `json:"tableID"`
 		Spectators []*Spectator `json:"spectators"`
 	}
-	s.Emit("spectators", &SpectatorsMessage{
+
+	command := "spectators"
+	if t.Game == nil {
+		command = "pregameSpectators"
+	}
+
+	s.Emit(command, &SpectatorsMessage{
 		TableID:    t.ID,
 		Spectators: t.Spectators,
 	})

--- a/server/src/session_notify.go
+++ b/server/src/session_notify.go
@@ -167,6 +167,17 @@ func (s *Session) NotifyTableStart(t *Table) {
 	})
 }
 
+func (s *Session) NotifyTableJoinedAsSpectator(t *Table) {
+	type TableJoinAsSpectator struct {
+		TableID uint64 `json:"tableID"`
+		Replay  bool   `json:"replay"`
+	}
+	s.Emit("tableJoinedAsSpectator", &TableJoinAsSpectator{
+		TableID: t.ID,
+		Replay:  t.Replay,
+	})
+}
+
 func (s *Session) NotifyShutdown() {
 	type ShutdownMessage struct {
 		ShuttingDown         bool      `json:"shuttingDown"`

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -617,8 +617,12 @@
                 <span id="lobby-pregame-seats"></span>
               </h4>
               <h4 class="padding0p5">
-                <span id="lobby-pregame-options-title"><strong>Options:</strong></span><br />
+                <span id="lobby-pregame-options-title">Options:</span><br />
                 <ul id="lobby-pregame-options"></ul>
+              </h4>
+              <h4 class="padding0p5">
+                <strong><i class="fas fa-glasses"></i>&nbsp; Spectators:</strong><br />
+                <ul id="lobby-pregame-spectators"></ul>
               </h4>
             </div>
             <div class="lobby-pregame-players">


### PR DESCRIPTION
Closes #1253 
Addresses #2553 
Closes #2605 

- Fixed asking for cursor image each time (svg in css file)
- Replaced creepy eye cursor with beloved googly eyes
- In lobby: click the spectators column on a pregame to join as a spectator
- In pregame: notifications when players join game or spectators join table
- In pregame: when table owner leaves, ownership is passed on to the next of kin
