### PR TITLE
Note bug fixes, turn count added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ motd.txt*
 /logs
 /ongoing_tables
 
+# Development files
+*.code-workspace
+package-lock.json
+
 # Private keys
 GitHub_private_key.pem
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ motd.txt*
 
 # Development files
 *.code-workspace
-package-lock.json
 
 # Private keys
 GitHub_private_key.pem

--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -1182,21 +1182,24 @@ export default class HanabiCard
       this.setNote(`[${note}]`);
     } else {
       const lastPipe = noteText.lastIndexOf("|");
-      const lastNote = noteText.slice(lastPipe + 1).trim();
-      const currentNote = parseNote(this.variant, lastNote);
-      const bracketedNote = lastNote.startsWith("[")
-        ? `${lastNote}`
-        : `[${lastNote}]`;
-      const appendedNote = `${bracketedNote} [${note}]`;
+      let lastNoteString = noteText.slice(lastPipe + 1).trim();
+      let currentNote = parseNote(this.variant, lastNoteString);
+      const bracketNoteString = `[${lastNoteString}]`;
+      const bracketNote = parseNote(this.variant, bracketNoteString);
+      // Protect notes like 'k3' whose meaning is preserved by bracketing ([k3])
+      if (
+        noteHasMeaning(this.variant, currentNote) &&
+        noteEqual(currentNote, bracketNote)
+      ) {
+        lastNoteString = bracketNoteString;
+        currentNote = bracketNote;
+      }
+      const appendedNoteString = `${lastNoteString} [${note}]`;
       // Case of: adding note does not change note meaning
-      if (noteEqual(currentNote, parseNote(this.variant, appendedNote))) {
+      if (noteEqual(bracketNote, parseNote(this.variant, appendedNoteString))) {
         return;
       }
-      if (!noteHasMeaning(this.variant, currentNote)) {
-        this.setNote(`${noteText} | [${note}]`);
-      } else {
-        this.setNote(`${noteText} | ${appendedNote}`);
-      }
+      this.setNote(`${noteText} | ${appendedNoteString}`);
     }
   }
 

--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -1182,21 +1182,21 @@ export default class HanabiCard
       this.setNote(`[${note}]`);
     } else {
       const lastPipe = noteText.lastIndexOf("|");
-      let lastNoteString = noteText.slice(lastPipe + 1).trim();
-      let currentNote = parseNote(this.variant, lastNoteString);
-      const bracketNoteString = `[${lastNoteString}]`;
+      let currentNoteString = noteText.slice(lastPipe + 1).trim();
+      let currentNote = parseNote(this.variant, currentNoteString);
+      const bracketNoteString = `[${currentNoteString}]`;
       const bracketNote = parseNote(this.variant, bracketNoteString);
-      // Protect notes like 'k3' whose meaning is preserved by bracketing ([k3])
+      // Protect notes like 'k3' whose meaning is preserved by bracketing: '[k3]'
       if (
         noteHasMeaning(this.variant, currentNote) &&
         noteEqual(currentNote, bracketNote)
       ) {
-        lastNoteString = bracketNoteString;
+        currentNoteString = bracketNoteString;
         currentNote = bracketNote;
       }
-      const appendedNoteString = `${lastNoteString} [${note}]`;
-      // Case of: adding note does not change note meaning
-      if (noteEqual(bracketNote, parseNote(this.variant, appendedNoteString))) {
+      const appendedNoteString = `${currentNoteString} [${note}]`;
+      // Case of: updating note does not change note meaning.
+      if (noteEqual(currentNote, parseNote(this.variant, appendedNoteString))) {
         return;
       }
       this.setNote(`${noteText} | ${appendedNoteString}`);

--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -1174,6 +1174,35 @@ export default class HanabiCard
     }
   }
 
+  prependNote(note: string): void {
+    const existingNote =
+      globals.state.notes.ourNotes[this.state.order]?.text ?? "";
+    const noteText = existingNote.trim();
+    const lastPipe = noteText.lastIndexOf("|");
+    const currentNoteString = noteText.slice(lastPipe + 1).trim();
+    const noteString = this.protectedNote(currentNoteString);
+    if (lastPipe === -1) {
+      this.setNote(`${note}${noteString}`);
+    } else {
+      this.setNote(
+        `${noteText.slice(0, lastPipe).trim()} | ${note}${noteString}`,
+      );
+    }
+  }
+
+  protectedNote(noteString: string): string {
+    const currentNote = parseNote(this.variant, noteString);
+    const bracketNoteString = `[${noteString}]`;
+    // Protect notes like 'k3' whose meaning is preserved by bracketing: '[k3]'
+    if (
+      noteHasMeaning(this.variant, currentNote) &&
+      noteEqual(currentNote, parseNote(this.variant, bracketNoteString))
+    ) {
+      return bracketNoteString;
+    }
+    return noteString;
+  }
+
   appendNote(note: string): void {
     const existingNote =
       globals.state.notes.ourNotes[this.state.order]?.text ?? "";
@@ -1182,19 +1211,10 @@ export default class HanabiCard
       this.setNote(`[${note}]`);
     } else {
       const lastPipe = noteText.lastIndexOf("|");
-      let currentNoteString = noteText.slice(lastPipe + 1).trim();
-      let currentNote = parseNote(this.variant, currentNoteString);
-      const bracketNoteString = `[${currentNoteString}]`;
-      const bracketNote = parseNote(this.variant, bracketNoteString);
-      // Protect notes like 'k3' whose meaning is preserved by bracketing: '[k3]'
-      if (
-        noteHasMeaning(this.variant, currentNote) &&
-        noteEqual(currentNote, bracketNote)
-      ) {
-        currentNoteString = bracketNoteString;
-        currentNote = bracketNote;
-      }
-      const appendedNoteString = `${currentNoteString} [${note}]`;
+      const currentNoteString = noteText.slice(lastPipe + 1).trim();
+      const noteString = this.protectedNote(currentNoteString);
+      const currentNote = parseNote(this.variant, noteString);
+      const appendedNoteString = `${noteString} [${note}]`;
       // Case of: updating note does not change note meaning.
       if (noteEqual(currentNote, parseNote(this.variant, appendedNoteString))) {
         return;

--- a/packages/client/src/game/ui/HanabiCardClick.ts
+++ b/packages/client/src/game/ui/HanabiCardClick.ts
@@ -207,6 +207,22 @@ function clickRight(card: HanabiCard, event: MouseEvent) {
     return;
   }
 
+  // Ctrl + Alt + right-click is edit a note + turn count.
+  if (
+    event.ctrlKey &&
+    event.shiftKey &&
+    event.altKey &&
+    !event.metaKey &&
+    globals.state.playing
+  ) {
+    notes.openEditTooltip(
+      card,
+      true,
+      `#${globals.elements.turnNumberLabel?.text()} `,
+    );
+    return;
+  }
+
   // A normal right-click is edit a note.
   if (
     !event.ctrlKey &&

--- a/packages/client/src/game/ui/HanabiCardClick.ts
+++ b/packages/client/src/game/ui/HanabiCardClick.ts
@@ -119,6 +119,8 @@ function clickMiddle(card: HanabiCard, event: MouseEvent) {
   }
 }
 
+let lastNote = "";
+
 function clickRight(card: HanabiCard, event: MouseEvent) {
   // Alt + right-click is a card morph (in a hypothetical).
   if (
@@ -159,11 +161,21 @@ function clickRight(card: HanabiCard, event: MouseEvent) {
   if (
     event.ctrlKey &&
     event.shiftKey &&
-    !event.altKey &&
     !event.metaKey &&
     globals.state.playing
   ) {
-    card.setNote(globals.lastNote);
+    if (event.altKey) {
+      // When Alt is held, copy only the new part of the last note.
+      if (lastNote === "") {
+        const noteText = globals.lastNote;
+        const lastPipe = noteText.lastIndexOf("|");
+        const lastNoteString = noteText.slice(lastPipe + 1).trim();
+        lastNote = lastNoteString;
+      }
+      card.appendNoteOnly(lastNote);
+    } else {
+      card.setNote(globals.lastNote);
+    }
     return;
   }
 
@@ -175,7 +187,8 @@ function clickRight(card: HanabiCard, event: MouseEvent) {
     !event.metaKey &&
     globals.state.playing
   ) {
-    card.appendNote("f");
+    lastNote = "f";
+    card.appendNote(lastNote);
     return;
   }
 
@@ -188,7 +201,8 @@ function clickRight(card: HanabiCard, event: MouseEvent) {
     !event.metaKey &&
     globals.state.playing
   ) {
-    card.appendNote("cm");
+    lastNote = "cm";
+    card.appendNote(lastNote);
     return;
   }
 
@@ -215,7 +229,8 @@ function clickRight(card: HanabiCard, event: MouseEvent) {
     !event.metaKey &&
     globals.state.playing
   ) {
-    card.prependNote(`#${globals.elements.turnNumberLabel?.text()} `);
+    lastNote = `#${globals.elements.turnNumberLabel?.text()}`;
+    card.prependNote(lastNote);
     return;
   }
 
@@ -227,6 +242,7 @@ function clickRight(card: HanabiCard, event: MouseEvent) {
     !event.metaKey &&
     !globals.state.finished
   ) {
+    lastNote = "";
     notes.openEditTooltip(card);
   }
 }

--- a/packages/client/src/game/ui/HanabiCardClick.ts
+++ b/packages/client/src/game/ui/HanabiCardClick.ts
@@ -207,19 +207,15 @@ function clickRight(card: HanabiCard, event: MouseEvent) {
     return;
   }
 
-  // Ctrl + Alt + right-click is edit a note + turn count.
+  // Ctrl + Alt + right-click is prepend turn count.
   if (
     event.ctrlKey &&
-    event.shiftKey &&
+    !event.shiftKey &&
     event.altKey &&
     !event.metaKey &&
     globals.state.playing
   ) {
-    notes.openEditTooltip(
-      card,
-      true,
-      `#${globals.elements.turnNumberLabel?.text()} `,
-    );
+    card.prependNote(`#${globals.elements.turnNumberLabel?.text()} `);
     return;
   }
 

--- a/packages/data/src/abbreviations.ts
+++ b/packages/data/src/abbreviations.ts
@@ -21,7 +21,7 @@ export const CHOP_MOVED_NOTES = [
 export const FINESSED_NOTES = ["f", "hf", "pf", "gd", "utf"];
 export const NEEDS_FIX_NOTES = ["fix", "fixme", "needs fix"];
 export const BLANK_NOTES = ["blank"];
-export const CLUED_NOTES = ["clued", "y"];
+export const CLUED_NOTES = ["clued", "yy"];
 export const UNCLUED_NOTES = ["unclued", "x"];
 
 export const ALL_RESERVED_NOTES = ([] as string[]).concat(

--- a/packages/data/src/abbreviations.ts
+++ b/packages/data/src/abbreviations.ts
@@ -21,7 +21,7 @@ export const CHOP_MOVED_NOTES = [
 export const FINESSED_NOTES = ["f", "hf", "pf", "gd", "utf"];
 export const NEEDS_FIX_NOTES = ["fix", "fixme", "needs fix"];
 export const BLANK_NOTES = ["blank"];
-export const CLUED_NOTES = ["clued", "yy"];
+export const CLUED_NOTES = ["clued", "cl"];
 export const UNCLUED_NOTES = ["unclued", "x"];
 
 export const ALL_RESERVED_NOTES = ([] as string[]).concat(

--- a/packages/data/src/abbreviations.ts
+++ b/packages/data/src/abbreviations.ts
@@ -21,7 +21,7 @@ export const CHOP_MOVED_NOTES = [
 export const FINESSED_NOTES = ["f", "hf", "pf", "gd", "utf"];
 export const NEEDS_FIX_NOTES = ["fix", "fixme", "needs fix"];
 export const BLANK_NOTES = ["blank"];
-export const CLUED_NOTES = ["clued"];
+export const CLUED_NOTES = ["clued", "y"];
 export const UNCLUED_NOTES = ["unclued", "x"];
 
 export const ALL_RESERVED_NOTES = ([] as string[]).concat(


### PR DESCRIPTION
* Fixed bug created by HTML parsing notes: "<foo" would not show anything.
* Fixed bug with meaningful notes getting surrounded by brackets: "[k3] some text" -> "[[k3] some text] [cm]"
* Added automated turn count to notes with ctrl + alt + right-click