### PR TITLE
Save spectator notes

### DIFF
--- a/packages/client/src/game/reducers/notesReducer.ts
+++ b/packages/client/src/game/reducers/notesReducer.ts
@@ -83,6 +83,7 @@ function notesReducerFunction(
           notes.allNotes[order]!.push({
             name: action.names[i]!,
             text,
+            isSpectator: action.isSpectators[i]!,
           });
         });
       });

--- a/packages/client/src/game/types/SpectatorNote.ts
+++ b/packages/client/src/game/types/SpectatorNote.ts
@@ -2,4 +2,5 @@ export default interface SpectatorNote {
   // This is the username of the person setting the note.
   readonly name: string;
   readonly text: string;
+  readonly isSpectator: boolean;
 }

--- a/packages/client/src/game/types/actions.ts
+++ b/packages/client/src/game/types/actions.ts
@@ -214,6 +214,7 @@ interface ActionNoteList {
   type: "noteList";
   readonly names: string[];
   readonly noteTextLists: string[][];
+  readonly isSpectators: boolean[];
 }
 
 interface ActionSetEffMod {

--- a/packages/client/src/game/ui/gameCommands.ts
+++ b/packages/client/src/game/ui/gameCommands.ts
@@ -207,17 +207,21 @@ interface NoteListData {
 interface NoteList {
   name: string;
   notes: string[];
+  isSpectator: boolean;
 }
 commands.set("noteList", (data: NoteListData) => {
   const names = [] as string[];
   const noteTextLists = [] as string[][];
+  const isSpectators = [] as boolean[];
   for (const noteList of data.notes) {
     names.push(noteList.name);
     noteTextLists.push(noteList.notes);
+    isSpectators.push(noteList.isSpectator);
   }
   globals.store!.dispatch({
     type: "noteList",
     names,
+    isSpectators,
     noteTextLists,
   });
   // Show the note indicator for currently-visible cards.

--- a/packages/client/src/game/ui/notes.ts
+++ b/packages/client/src/game/ui/notes.ts
@@ -28,10 +28,19 @@ function get(order: number, our: boolean, escape = false) {
   // Build a string that shows the combined notes from the players & spectators.
   let content = "";
   const noteObjectArray = globals.state.notes.allNotes[order]!;
+  let firstSpectator = false;
   for (const noteObject of noteObjectArray) {
     const name = escapeFunc(noteObject.name);
     const text = escapeFunc(noteObject.text);
+    const { isSpectator } = noteObject;
     if (noteObject.text.length > 0) {
+      if (!firstSpectator && Boolean(isSpectator)) {
+        firstSpectator = true;
+        if (content.length > 0) {
+          content = `<div class='noteTitle'><span>Players</span></div>${content}`;
+        }
+        content += "<div class='noteTitle'><span>Spectators</span></div>";
+      }
       content += `<strong>${name}:</strong> ${text}<br />`;
     }
   }

--- a/public/css/hanabi.css
+++ b/public/css/hanabi.css
@@ -1833,3 +1833,19 @@ span.tableSpinner:after {
   width: 0.75em;
   display: inline-block;
 }
+
+div.noteTitle {
+  width: 100%;
+  height: 10px;
+  border-bottom: 1px solid #777;
+  text-align: center;
+  margin-bottom: 7px;
+  line-height: 10px;
+}
+
+div.noteTitle span {
+  font-size: 14px;
+  background-color: #fff;
+  text-align: center;
+  padding: 0 10px;
+}

--- a/server/src/command_chat.go
+++ b/server/src/command_chat.go
@@ -28,10 +28,11 @@ var (
 // so we have to check for this before displaying WebSocket error messages
 //
 // Example data:
-// {
-//   msg: 'hi',
-//   room: 'lobby', // Room can also be "table1", "table1234", etc.
-// }
+//
+//	{
+//	  msg: 'hi',
+//	  room: 'lobby', // Room can also be "table1", "table1234", etc.
+//	}
 func commandChat(ctx context.Context, s *Session, d *CommandData) {
 	// Local variables
 	var userID int
@@ -194,9 +195,7 @@ func commandChatTable(ctx context.Context, s *Session, d *CommandData) {
 	var playerIndex int
 	var spectatorIndex int
 	if !d.Server {
-		playerIndex = t.GetPlayerIndexFromID(s.UserID)
-		spectatorIndex = t.GetSpectatorIndexFromID(s.UserID)
-		if playerIndex == -1 && spectatorIndex == -1 {
+		if !t.IsPlayerOrSpectating(s.UserID) {
 			s.Warning("You are not playing or spectating at table " + strconv.FormatUint(t.ID, 10) +
 				", so you cannot send chat to it.")
 			return

--- a/server/src/command_chat_read.go
+++ b/server/src/command_chat_read.go
@@ -8,9 +8,10 @@ import (
 // when they receive a chat message when the in-game chat is already open
 //
 // Example data:
-// {
-//   tableID: 5,
-// }
+//
+//	{
+//	  tableID: 5,
+//	}
 func commandChatRead(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -21,14 +22,12 @@ func commandChatRead(ctx context.Context, s *Session, d *CommandData) {
 	}
 
 	// Validate that they are in the game or are a spectator
-	playerIndex := t.GetPlayerIndexFromID(s.UserID)
-	spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
-	if playerIndex == -1 && spectatorIndex == -1 {
+	if !t.IsPlayerOrSpectating(s.UserID) {
 		// Return without an error message if they are not playing or spectating at the table
 		// (to account for lag)
 		return
 	}
-	if spectatorIndex == -1 && t.Replay {
+	if !t.IsActivelySpectating(s.UserID) && t.Replay {
 		// Return without an error message if they are not spectating at the replay
 		// (to account for lag)
 		return

--- a/server/src/command_chat_typing.go
+++ b/server/src/command_chat_typing.go
@@ -13,9 +13,10 @@ const (
 // commandChatTyping is sent when the user types something into a chat box
 //
 // Example data:
-// {
-//   tableID: 15103,
-// }
+//
+//	{
+//	  tableID: 15103,
+//	}
 func commandChatTyping(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -28,12 +29,12 @@ func commandChatTyping(ctx context.Context, s *Session, d *CommandData) {
 	// Validate that they are in the game or are a spectator
 	playerIndex := t.GetPlayerIndexFromID(s.UserID)
 	spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
-	if playerIndex == -1 && spectatorIndex == -1 {
+	if !t.IsPlayerOrSpectating(s.UserID) {
 		s.Warning("You are not playing or spectating at table " + strconv.FormatUint(t.ID, 10) +
 			", so you cannot report that you are typing.")
 		return
 	}
-	if spectatorIndex == -1 && t.Replay {
+	if !t.IsActivelySpectating(s.UserID) && t.Replay {
 		s.Warning("You are not spectating replay " + strconv.FormatUint(t.ID, 10) +
 			", so you cannot report that you are typing.")
 		return
@@ -86,13 +87,13 @@ func chatTypingCheckStopped(ctx context.Context, t *Table, userID int) {
 	// Validate that they are in the game or are a spectator
 	playerIndex := t.GetPlayerIndexFromID(userID)
 	spectatorIndex := t.GetSpectatorIndexFromID(userID)
-	if playerIndex == -1 && spectatorIndex == -1 {
+	if !t.IsPlayerOrSpectating(userID) {
 		// They left the game shortly after they started typing
 		// The "typing" message is automatically removed when a player leaves a table,
 		// so we don't have to do anything
 		return
 	}
-	if spectatorIndex == -1 && t.Replay {
+	if !t.IsActivelySpectating(userID) && t.Replay {
 		// Same as above
 		return
 	}

--- a/server/src/command_get_game_info_1.go
+++ b/server/src/command_get_game_info_1.go
@@ -20,9 +20,10 @@ import (
 // the client will send a "getGameInfo2" command later to get more specific data
 //
 // Example data:
-// {
-//   tableID: 5,
-// }
+//
+//	{
+//	  tableID: 5,
+//	}
 func commandGetGameInfo1(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -41,7 +42,7 @@ func commandGetGameInfo1(ctx context.Context, s *Session, d *CommandData) {
 	// Validate that they are either playing or spectating the game
 	playerIndex := t.GetPlayerIndexFromID(s.UserID)
 	spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
-	if playerIndex == -1 && spectatorIndex == -1 {
+	if !t.IsPlayerOrSpectating(s.UserID) {
 		s.Warning("You are not playing or spectating at table " + strconv.FormatUint(t.ID, 10) +
 			".")
 		return
@@ -140,7 +141,7 @@ func getGameInfo1(s *Session, t *Table, playerIndex int, spectatorIndex int) {
 		TableID:          t.ID, // The client needs to know the table ID for chat to work properly
 		PlayerNames:      playerNames,
 		OurPlayerIndex:   ourPlayerIndex,
-		Spectating:       spectatorIndex != -1 && !t.Replay,
+		Spectating:       spectatorIndex != -1 && t.Spectators[spectatorIndex].Active && !t.Replay,
 		Replay:           t.Replay,
 		DatabaseID:       t.ExtraOptions.DatabaseID,
 		HasCustomSeed:    g.ExtraOptions.CustomSeed != "",

--- a/server/src/command_get_game_info_2.go
+++ b/server/src/command_get_game_info_2.go
@@ -9,9 +9,10 @@ import (
 // It is sent when the user has joined a game and the UI has been initialized
 //
 // Example data:
-// {
-//   tableID: 5,
-// }
+//
+//	{
+//	  tableID: 5,
+//	}
 func commandGetGameInfo2(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -30,7 +31,7 @@ func commandGetGameInfo2(ctx context.Context, s *Session, d *CommandData) {
 	// Validate that they are either a player or a spectator
 	playerIndex := t.GetPlayerIndexFromID(s.UserID)
 	spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
-	if playerIndex == -1 && spectatorIndex == -1 {
+	if !t.IsPlayerOrSpectating(s.UserID) {
 		s.Warning("You are not a player or a spectator at table " +
 			strconv.FormatUint(t.ID, 10) + ", so you cannot be ready for it.")
 		return
@@ -101,7 +102,9 @@ func getGameInfo2(s *Session, t *Table, playerIndex int, spectatorIndex int) {
 		} else if spectatorIndex > -1 {
 			// They are a spectator in an ongoing game
 			sp := t.Spectators[spectatorIndex]
-			s.NotifyNoteList(t, sp.ShadowingPlayerIndex)
+			if sp.Active {
+				s.NotifyNoteList(t, sp.ShadowingPlayerIndex)
+			}
 		}
 	}
 
@@ -118,7 +121,7 @@ func getGameInfo2(s *Session, t *Table, playerIndex int, spectatorIndex int) {
 				s.NotifyChatTyping(t, p.Name, p.Typing)
 			}
 		}
-		for _, sp := range t.Spectators {
+		for _, sp := range t.ActiveSpectators() {
 			if sp.Typing {
 				s.NotifyChatTyping(t, sp.Name, sp.Typing)
 			}

--- a/server/src/command_note.go
+++ b/server/src/command_note.go
@@ -12,11 +12,12 @@ import (
 // commandNote is sent when the user writes a note
 //
 // Example data:
-// {
-//   tableID: 5,
-//   order: 3,
-//   note: 'b1, m1',
-// }
+//
+//	{
+//	  tableID: 5,
+//	  order: 3,
+//	  note: 'b1, m1',
+//	}
 func commandNote(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -41,7 +42,7 @@ func commandNote(ctx context.Context, s *Session, d *CommandData) {
 	// Validate that they are in the game
 	playerIndex := t.GetPlayerIndexFromID(s.UserID)
 	spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
-	if playerIndex == -1 && spectatorIndex == -1 {
+	if !t.IsPlayerOrSpectating(s.UserID) {
 		s.Warning("You are not at table " + strconv.FormatUint(t.ID, 10) + ", " +
 			"so you cannot send a note.")
 		return

--- a/server/src/command_replay_action.go
+++ b/server/src/command_replay_action.go
@@ -30,12 +30,13 @@ func replayActionsFunctionsInit() {
 // commandReplayAction is sent when the user performs an action in a shared replay
 //
 // Example data:
-// {
-//   tableID: 5,
-//   type: 0, // Types are listed in the "constants.go" file
-//   value: 10, // Optional
-//   name: 'Alice', // Optional
-// }
+//
+//	{
+//	  tableID: 5,
+//	  type: 0, // Types are listed in the "constants.go" file
+//	  value: 10, // Optional
+//	  name: 'Alice', // Optional
+//	}
 func commandReplayAction(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -53,8 +54,7 @@ func commandReplayAction(ctx context.Context, s *Session, d *CommandData) {
 	}
 
 	// Validate that this person is spectating the shared replay
-	j := t.GetSpectatorIndexFromID(s.UserID)
-	if j < -1 {
+	if !t.IsActivelySpectating(s.UserID) {
 		s.Warning("You are not in shared replay " + strconv.FormatUint(t.ID, 10) + ".")
 	}
 
@@ -97,7 +97,7 @@ func replayActionSegment(s *Session, d *CommandData, t *Table) {
 		TableID: t.ID,
 		Segment: d.Segment,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("replaySegment", replaySegmentMessage)
 	}
 
@@ -135,7 +135,7 @@ func replayActionArrow(s *Session, d *CommandData, t *Table) {
 		TableID: t.ID,
 		Order:   d.Order,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("replayIndicator", replayIndicatorMessage)
 	}
 }
@@ -150,7 +150,7 @@ func replayActionSound(s *Session, d *CommandData, t *Table) {
 		TableID: t.ID,
 		Sound:   d.Sound,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("replaySound", replaySoundMessage)
 	}
 }
@@ -174,7 +174,7 @@ func replayActionHypoStart(s *Session, d *CommandData, t *Table) {
 	hypoStartMessage := &HypoStartMessage{
 		TableID: t.ID,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("hypoStart", hypoStartMessage)
 	}
 }
@@ -198,7 +198,7 @@ func replayActionHypoEnd(s *Session, d *CommandData, t *Table) {
 	hypoEndMessage := &HypoEndMessage{
 		TableID: t.ID,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("hypoEnd", hypoEndMessage)
 	}
 }
@@ -223,7 +223,7 @@ func replayActionHypoAction(s *Session, d *CommandData, t *Table) {
 	// Perform a move in the hypothetical
 	g.HypoActions = append(g.HypoActions, d.ActionJSON)
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("hypoAction", d.ActionJSON)
 	}
 }
@@ -259,7 +259,7 @@ func replayActionHypoBack(s *Session, d *CommandData, t *Table) {
 	hypoBackMessage := &HypoBackMessage{
 		TableID: t.ID,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("hypoBack", hypoBackMessage)
 	}
 }
@@ -278,7 +278,7 @@ func replayActionToggleRevealed(s *Session, d *CommandData, t *Table) {
 		TableID:        t.ID,
 		ShowDrawnCards: g.HypoShowDrawnCards,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("hypoShowDrawnCards", hypoShowDrawnCardsMessage)
 	}
 }
@@ -296,7 +296,7 @@ func replayActionEfficiencyMod(s *Session, d *CommandData, t *Table) {
 		TableID: t.ID,
 		Mod:     g.EfficiencyMod,
 	}
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("replayEfficiencyMod", replayEfficiencyModMessage)
 	}
 }

--- a/server/src/command_table_spectate.go
+++ b/server/src/command_table_spectate.go
@@ -15,11 +15,12 @@ import (
 // 4) on behalf of a user when they reconnect after having been in a shared replay
 //
 // Example data:
-// {
-//   tableID: 15103,
-//   // A value of "-1" must be specified if we do not want to shadow a player
-//   shadowingPlayerIndex: -1,
-// }
+//
+//	{
+//	  tableID: 15103,
+//	  // A value of "-1" must be specified if we do not want to shadow a player
+//	  shadowingPlayerIndex: -1,
+//	}
 func commandTableSpectate(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -40,10 +41,12 @@ func commandTableSpectate(ctx context.Context, s *Session, d *CommandData) {
 	}
 
 	// Validate that they are not already spectating this table
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		if sp.UserID == s.UserID {
-			s.Warning("You are already spectating this table.")
-			return
+			if sp.Active {
+				s.Warning("You are already spectating this table.")
+				return
+			}
 		}
 	}
 
@@ -88,17 +91,24 @@ func tableSpectate(ctx context.Context, s *Session, d *CommandData, t *Table) {
 	// (this will be a no-op if they were not in the "DisconSpectators" map)
 	tables.DeleteDisconSpectating(s.UserID)
 
-	// Add them to the spectators object
-	sp := &Spectator{
-		UserID:               s.UserID,
-		Name:                 s.Username,
-		Session:              s,
-		Typing:               false,
-		LastTyped:            time.Time{},
-		ShadowingPlayerIndex: d.ShadowingPlayerIndex,
+	spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
+	if spectatorIndex == -1 {
+		// Add them to the spectators object
+		sp := &Spectator{
+			UserID:               s.UserID,
+			Name:                 s.Username,
+			Session:              s,
+			Active:               true,
+			Typing:               false,
+			LastTyped:            time.Time{},
+			ShadowingPlayerIndex: d.ShadowingPlayerIndex,
+		}
+		t.Spectators = append(t.Spectators, sp)
+	} else {
+		t.Spectators[spectatorIndex].Active = true
+		t.Spectators[spectatorIndex].ShadowingPlayerIndex = d.ShadowingPlayerIndex
 	}
 
-	t.Spectators = append(t.Spectators, sp)
 	tables.AddSpectating(s.UserID, t.ID) // Keep track of user to table relationships
 
 	notifyAllTable(t) // Update the spectator list for the row in the lobby

--- a/server/src/command_table_start.go
+++ b/server/src/command_table_start.go
@@ -15,9 +15,10 @@ import (
 // game)
 //
 // Example data:
-// {
-//   tableID: 5,
-// }
+//
+//	{
+//	  tableID: 5,
+//	}
 func commandTableStart(ctx context.Context, s *Session, d *CommandData) {
 	t, exists := getTableAndLock(ctx, s, d.TableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
@@ -271,7 +272,7 @@ func tableStart(ctx context.Context, s *Session, d *CommandData, t *Table) {
 			p.Session.NotifyTableStart(t)
 		}
 	}
-	for _, s := range t.Spectators {
+	for _, s := range t.ActiveSpectators() {
 		s.Session.NotifyTableStart(t)
 	}
 

--- a/server/src/command_table_unattend.go
+++ b/server/src/command_table_unattend.go
@@ -13,9 +13,10 @@ import (
 // 3) viewing a reply or shared replay
 //
 // Example data:
-// {
-//   tableID: 5,
-// }
+//
+//	{
+//	  tableID: 5,
+//	}
 func commandTableUnattend(ctx context.Context, s *Session, d *CommandData) {
 	// Unlike other command handlers, we do not want to show a warning to the user if the table does
 	// not exist, so we pass "nil" instead of "s" to the "getTableAndLock()" function
@@ -32,12 +33,12 @@ func commandTableUnattend(ctx context.Context, s *Session, d *CommandData) {
 	// Validate that they are either playing or spectating the game
 	playerIndex := t.GetPlayerIndexFromID(s.UserID)
 	spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
-	if playerIndex == -1 && spectatorIndex == -1 {
+	if !t.IsPlayerOrSpectating(s.UserID) {
 		s.Warning("You are not playing or spectating at table " + strconv.FormatUint(t.ID, 10) +
 			", so you cannot unattend it.")
 		return
 	}
-	if spectatorIndex == -1 && t.Replay {
+	if !t.IsActivelySpectating(s.UserID) && t.Replay {
 		s.Warning("You are not spectating replay " + strconv.FormatUint(t.ID, 10) +
 			", so you cannot unattend it.")
 		return
@@ -81,21 +82,11 @@ func tableUnattendSpectator(ctx context.Context, s *Session, d *CommandData, t *
 		defer tables.Unlock(ctx)
 	}
 
-	// If this is an ongoing game, create a list of card orders which they wrote a note on
-	notedCards := make([]int, 0)
-	if t.Running {
-		sp := t.Spectators[j]
-		for order, note := range sp.Notes(t.Game) {
-			if note != "" {
-				notedCards = append(notedCards, order)
-			}
-		}
-	}
-
-	t.Spectators = append(t.Spectators[:j], t.Spectators[j+1:]...)
+	sp := t.Spectators[j]
+	sp.Active = false
 	tables.DeleteSpectating(s.UserID, t.ID) // Keep track of user to table relationships
 
-	if t.Replay && len(t.Spectators) == 0 {
+	if t.Replay && len(t.ActiveSpectators()) == 0 {
 		// This was the last person to leave the replay, so delete it
 		deleteTable(t)
 		logger.Info("Ended replay #" + strconv.FormatUint(t.ID, 10) + " because everyone left.")
@@ -109,12 +100,4 @@ func tableUnattendSpectator(ctx context.Context, s *Session, d *CommandData, t *
 		chatServerSend(ctx, msg, t.GetRoomName(), true)
 	}
 	t.NotifySpectators() // Update the in-game spectator list
-
-	if len(notedCards) > 0 {
-		// Since this is a spectator leaving an ongoing game, all of their notes will be deleted
-		// Send the other spectators a message about the new list of notes, if any
-		for _, order := range notedCards {
-			t.NotifySpectatorsNote(order)
-		}
-	}
 }

--- a/server/src/game_end.go
+++ b/server/src/game_end.go
@@ -374,16 +374,23 @@ func (t *Table) ConvertToSharedReplay(ctx context.Context, d *CommandData) {
 			continue
 		}
 
-		// Add the new spectator
-		sp := &Spectator{
-			UserID:               p.UserID,
-			Name:                 p.Name,
-			Session:              p.Session,
-			Typing:               false,
-			LastTyped:            time.Time{},
-			ShadowingPlayerIndex: -1, // To indicate that they are not shadowing anyone
+		spectatorIndex := t.GetSpectatorIndexFromID(p.UserID)
+		if spectatorIndex == -1 {
+			// Add the new spectator
+			sp := &Spectator{
+				UserID:               p.UserID,
+				Name:                 p.Name,
+				Session:              p.Session,
+				Active:               true,
+				Typing:               false,
+				LastTyped:            time.Time{},
+				ShadowingPlayerIndex: -1, // To indicate that they are not shadowing anyone
+			}
+			t.Spectators = append(t.Spectators, sp)
+		} else {
+			t.Spectators[spectatorIndex].Active = true
+			t.Spectators[spectatorIndex].ShadowingPlayerIndex = -1
 		}
-		t.Spectators = append(t.Spectators, sp)
 
 		// Also, keep track of user to table relationships
 		tables.DeletePlaying(p.UserID, t.ID)
@@ -393,7 +400,7 @@ func (t *Table) ConvertToSharedReplay(ctx context.Context, d *CommandData) {
 	}
 
 	// End the shared replay if no-one is left
-	if len(t.Spectators) == 0 {
+	if len(t.ActiveSpectators()) == 0 {
 		deleteTable(t)
 		logger.Info("Ended table #" + strconv.FormatUint(t.ID, 10) +
 			" because no-one was present when the game ended.")
@@ -416,7 +423,7 @@ func (t *Table) ConvertToSharedReplay(ctx context.Context, d *CommandData) {
 
 		if t.OwnerID == -1 {
 			// All of the players are away, so make the first spectator the leader
-			t.OwnerID = t.Spectators[0].UserID
+			t.OwnerID = t.ActiveSpectators()[0].UserID
 			logger.Info("All players are offline; set the new leader to be: " +
 				t.Spectators[0].Name)
 		}
@@ -436,7 +443,7 @@ func (t *Table) ConvertToSharedReplay(ctx context.Context, d *CommandData) {
 	// Notify everyone that the game is over and that they should prepare the UI for a shared replay
 	t.NotifyFinishOngoingGame()
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		// Reset everyone's status (both players and spectators are now spectators)
 		if sp.Session != nil {
 			sp.Session.SetStatus(StatusSharedReplay)

--- a/server/src/http_localhost_clear_empty_tables.go
+++ b/server/src/http_localhost_clear_empty_tables.go
@@ -24,7 +24,7 @@ func httpLocalhostClearEmptyTables(c *gin.Context) {
 				// A table that has not started yet (e.g. pregame)
 				deleteTable(t)
 				logger.Info("Successfully cleared pregame table #" + strconv.FormatUint(t.ID, 10) + ".")
-			} else if t.Replay && len(t.Spectators) == 0 {
+			} else if t.Replay && len(t.ActiveSpectators()) == 0 {
 				// A replay or shared replay
 				deleteTable(t)
 				logger.Info("Successfully cleared replay table #" + strconv.FormatUint(t.ID, 10) + ".")

--- a/server/src/print.go
+++ b/server/src/print.go
@@ -157,16 +157,16 @@ func printTablePlayers(t *Table) {
 }
 
 func printTableSpectators(t *Table) {
-	logger.Debug("    Spectators (" + strconv.Itoa(len(t.Spectators)) + "):")
+	logger.Debug("    Spectators (" + strconv.Itoa(len(t.ActiveSpectators())) + "):")
 	if t.Spectators == nil {
 		logger.Debug("      [Spectators is nil; this should never happen]")
 	} else {
-		for j, sp := range t.Spectators { // This is a []*Spectator
+		for j, sp := range t.ActiveSpectators() { // This is a []*Spectator
 			logger.Debug("        " + strconv.Itoa(j) + " - " +
 				"User ID: " + strconv.Itoa(sp.UserID) + ", " +
 				"Username: " + sp.Name)
 		}
-		if len(t.Spectators) == 0 {
+		if len(t.ActiveSpectators()) == 0 {
 			logger.Debug("        [no spectators]")
 		}
 	}

--- a/server/src/session_notify.go
+++ b/server/src/session_notify.go
@@ -89,7 +89,7 @@ func makeTableMessage(s *Session, t *Table) *TableMessage {
 	}
 
 	spectators := make([]string, 0)
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		spectators = append(spectators, sp.Name)
 	}
 
@@ -294,7 +294,7 @@ func (s *Session) NotifySpectators(t *Table) {
 
 	s.Emit(command, &SpectatorsMessage{
 		TableID:    t.ID,
-		Spectators: t.Spectators,
+		Spectators: t.ActiveSpectators(),
 	})
 }
 
@@ -350,8 +350,9 @@ func (s *Session) NotifyNoteList(t *Table, shadowingPlayerIndex int) {
 	g := t.Game
 
 	type NoteList struct {
-		Name  string   `json:"name"`
-		Notes []string `json:"notes"`
+		Name        string   `json:"name"`
+		Notes       []string `json:"notes"`
+		IsSpectator bool     `json:"isSpectator"`
 	}
 
 	// Get the notes from all the players & spectators
@@ -359,16 +360,18 @@ func (s *Session) NotifyNoteList(t *Table, shadowingPlayerIndex int) {
 	for _, p := range g.Players {
 		if shadowingPlayerIndex == -1 || shadowingPlayerIndex == p.Index {
 			notes = append(notes, NoteList{
-				Name:  p.Name,
-				Notes: p.Notes,
+				Name:        p.Name,
+				Notes:       p.Notes,
+				IsSpectator: false,
 			})
 		}
 	}
-	if !t.Replay && shadowingPlayerIndex == -1 {
+	if shadowingPlayerIndex == -1 {
 		for _, sp := range t.Spectators {
 			notes = append(notes, NoteList{
-				Name:  sp.Name,
-				Notes: sp.Notes(g),
+				Name:        sp.Name,
+				Notes:       sp.Notes(g),
+				IsSpectator: true,
 			})
 		}
 	}

--- a/server/src/spectator.go
+++ b/server/src/spectator.go
@@ -17,6 +17,7 @@ type Spectator struct {
 	Session   *Session  `json:"-"`
 	Typing    bool      `json:"-"`
 	LastTyped time.Time `json:"-"`
+	Active    bool      `json:"-"`
 
 	// Spectators have the ability to watch a game from a specific player's perspective
 	// Equal to -1 if they are not shadowing a specific player

--- a/server/src/table_notify.go
+++ b/server/src/table_notify.go
@@ -15,7 +15,7 @@ func (t *Table) NotifyChat(chatMessage *ChatMessage) {
 		}
 	}
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("chat", chatMessage)
 	}
 }
@@ -29,7 +29,7 @@ func (t *Table) NotifyChatTyping(name string, typing bool) {
 		}
 	}
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		if sp.Name != name { // We do not need to alert the person who is typing
 			sp.Session.NotifyChatTyping(t, name, typing)
 		}
@@ -110,7 +110,7 @@ func (t *Table) NotifyPlayerChange() {
 	}
 
 	// Emit game the information to all pregame spectators
-	for _, s := range t.Spectators {
+	for _, s := range t.ActiveSpectators() {
 		s.Session.Emit("game", &GameMessage{
 			TableID:           t.ID,
 			Name:              t.Name,
@@ -144,7 +144,7 @@ func (t *Table) NotifyConnected() {
 		}
 	}
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifyConnected(t)
 	}
 }
@@ -164,7 +164,7 @@ func (t *Table) NotifySpectators() {
 		}
 	}
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifySpectators(t)
 	}
 }
@@ -190,7 +190,7 @@ func (t *Table) NotifyGameAction() {
 	}
 
 	// Also send the spectators an update
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifyGameAction(t, a)
 	}
 }
@@ -235,13 +235,13 @@ func (t *Table) NotifyFinishOngoingGame() {
 	}
 
 	// At this point, all of the players will have been converted to spectators
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.Emit("finishOngoingGame", finishOngoingGameMessage)
 	}
 }
 
 func (t *Table) NotifyCardIdentities() {
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifyCardIdentities(t)
 	}
 }
@@ -253,7 +253,7 @@ func (t *Table) NotifyTime() {
 		}
 	}
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifyTime(t)
 	}
 }
@@ -265,13 +265,13 @@ func (t *Table) NotifyPause() {
 		}
 	}
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifyPause(t)
 	}
 }
 
 func (t *Table) NotifyReplayLeader() {
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifyReplayLeader(t)
 	}
 }
@@ -279,29 +279,32 @@ func (t *Table) NotifyReplayLeader() {
 func (t *Table) NotifySpectatorsNote(order int) {
 	g := t.Game
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		// Make an array that contains the combined notes for all the players & spectators
 		// (for a specific card)
 		// However, if this spectator is shadowing a specific player, then only include the note for
 		// the shadowed player
 		type Note struct {
-			Name string `json:"name"`
-			Text string `json:"text"`
+			Name        string `json:"name"`
+			Text        string `json:"text"`
+			IsSpectator bool   `json:"isSpectator"`
 		}
 		notes := make([]Note, 0)
 		for _, p := range g.Players {
 			if sp.ShadowingPlayerIndex == -1 || sp.ShadowingPlayerIndex == p.Index {
 				notes = append(notes, Note{
-					Name: p.Name,
-					Text: p.Notes[order],
+					Name:        p.Name,
+					Text:        p.Notes[order],
+					IsSpectator: false,
 				})
 			}
 		}
 		if sp.ShadowingPlayerIndex == -1 {
 			for _, sp2 := range t.Spectators {
 				notes = append(notes, Note{
-					Name: sp2.Name,
-					Text: sp2.Notes(g)[order],
+					Name:        sp2.Name,
+					Text:        sp2.Notes(g)[order],
+					IsSpectator: true,
 				})
 			}
 		}
@@ -347,7 +350,7 @@ func (t *Table) NotifyBoot() {
 		}
 	}
 
-	for _, sp := range t.Spectators {
+	for _, sp := range t.ActiveSpectators() {
 		sp.Session.NotifyBoot(t)
 	}
 }

--- a/server/src/tables.go
+++ b/server/src/tables.go
@@ -109,6 +109,9 @@ func (ts *Tables) Delete(tableID uint64) {
 		}
 	}
 	for _, userID := range usersSpectatingTable {
+		t := ts.tables[tableID]
+		sp := t.Spectators[t.GetSpectatorIndexFromID(userID)]
+		sp.Active = false
 		ts.DeleteSpectating(userID, tableID)
 	}
 }

--- a/server/src/websocket_disconnect.go
+++ b/server/src/websocket_disconnect.go
@@ -59,8 +59,7 @@ func websocketDisconnectRemoveFromGames(ctx context.Context, s *Session) {
 		}
 
 		// They could be one of the spectators (2/2)
-		spectatorIndex := t.GetSpectatorIndexFromID(s.UserID)
-		if spectatorIndex != -1 {
+		if t.IsActivelySpectating(s.UserID) {
 			spectatingTableIDs = append(spectatingTableIDs, t.ID)
 		}
 


### PR DESCRIPTION
Saving spectatornotes even if they change table.
Visually differenciate them from players notes.
Don't save spectators notes in the database.