### PR TITLE
VARIANTS.md: fix suit order

### DIFF
--- a/docs/VARIANTS.md
+++ b/docs/VARIANTS.md
@@ -29,10 +29,10 @@ One of each card per suit (e.g. 5 in total):
 ### No Variant
 
 - This is the "normal" game, with 5 suits. Unlike some other versions of the game, the website uses the following five suit colors:
-  - Blue
-  - Green
-  - Yellow
   - Red
+  - Yellow
+  - Green
+  - Blue
   - Purple
 
 ### 6 Suits


### PR DESCRIPTION
The 5 suit colours are listed in the old order (before they were made into rainbow order rygbp). Probably doesn't matter, but thought I'd point it out and fix it when I saw it.