### PR TITLE
Fix regex bug in /copy in hypo

### DIFF
--- a/packages/client/src/lobby/createReplayJSON.ts
+++ b/packages/client/src/lobby/createReplayJSON.ts
@@ -169,9 +169,9 @@ function getGameActionsFromState(source: ReplayState): ClientAction[] {
 
 function getGameActionsFromLog(log: readonly LogEntry[]): ClientAction[] {
   const actions: ClientAction[] = [];
-  const regexPlay = /^(.*)(?: plays | fails to play ).* from slot #(\d).*$/;
-  const regexDiscard = /^(.*) discards .* slot #(\d).*$/;
-  const regexClue = /^(?:.+) tells (.*) about \w+ ([a-zA-Z]+|\d)s?$/;
+  const regexPlay = /^(?:\[Hypo\] )?(.*)(?: plays | fails to play ).* from slot #(\d).*$/;
+  const regexDiscard = /^(?:\[Hypo\] )?(.*) discards .* slot #(\d).*$/;
+  const regexClue = /^(?:\[Hypo\] )?(?:.+) tells (.*) about \w+ ([a-zA-Z]+|\d)s?$/;
 
   log.forEach((line, index) => {
     const foundPlay = line.text.match(regexPlay);


### PR DESCRIPTION
Accidently missed to strip [Hypo] to the beginning of the player name when creating the json file after a play or a discard, which broke the function.