### PR TITLE
fix: eff counter colour for null/dark null

### DIFF
--- a/packages/client/src/game/rules/hGroup.ts
+++ b/packages/client/src/game/rules/hGroup.ts
@@ -6,11 +6,6 @@ import * as variantRules from "./variant";
 export function hardVariant(variant: Variant, minEfficiency: number): boolean {
   // Some variants are defined as always being hard, regardless of what the efficiency is.
   if (
-    // As long as the variant contains a "Null" or "Dark Null" suit, the variant is considered to be
-    // hard.
-    variant.suits.some(
-      (suit) => suit.name === "Null" || suit.name === "Dark Null",
-    ) ||
     variantRules.isMix(variant) ||
     variantRules.isColorMute(variant) ||
     variantRules.isNumberMute(variant) ||


### PR DESCRIPTION
They are no longer hard variants.