### PR TITLE
Patches a typo in CommandNote

### DIFF
--- a/server/src/command_note.go
+++ b/server/src/command_note.go
@@ -55,7 +55,7 @@ func commandNote(ctx context.Context, s *Session, d *CommandData) {
 	}
 
 	// Remove any non-printable characters, if any
-	d.Msg = removeNonPrintableCharacters(d.Msg)
+	d.Note = removeNonPrintableCharacters(d.Note)
 
 	// Check for valid UTF8
 	if !utf8.Valid([]byte(d.Note)) {
@@ -83,7 +83,7 @@ func commandNote(ctx context.Context, s *Session, d *CommandData) {
 	}
 
 	// Escape all HTML special characters (to stop various attacks against other players)
-	d.Msg = html.EscapeString(d.Msg)
+	d.Note = html.EscapeString(d.Note)
 
 	note(d, t, playerIndex, spectatorIndex)
 }

--- a/server/src/table.go
+++ b/server/src/table.go
@@ -429,10 +429,7 @@ func (t *Table) ActiveSpectators() []*Spectator {
 	for _, sp := range t.Spectators {
 		for _, tId := range tables.GetTablesUserSpectating(sp.UserID) {
 			if tId == t.ID {
-				logger.Info(sp.Name + " is active Spectator")
 				activeSpectators = append(activeSpectators, sp)
-			} else {
-				logger.Info(sp.Name + " is NOT active Spectator")
 			}
 		}
 	}


### PR DESCRIPTION
Realized we are escaping the wrong message when storing a new note.

Also removes a leftover debug line