### PR TITLE
Fixes empathy in hypos with morphed cards

### DIFF
--- a/packages/client/src/game/reducers/cardDeductionReducer.ts
+++ b/packages/client/src/game/reducers/cardDeductionReducer.ts
@@ -44,6 +44,7 @@ function makeDeductions(
     newDeck,
     oldDeck,
     cardCountMap,
+    metadata,
   );
   for (let playerIndex = 0; playerIndex < hands.length; playerIndex++) {
     if (playerIndex !== metadata.ourPlayerIndex) {
@@ -54,6 +55,7 @@ function makeDeductions(
         newDeck,
         oldDeck,
         cardCountMap,
+        metadata,
       );
     }
   }
@@ -67,6 +69,7 @@ function calculatePlayerPossibilities(
   deck: CardState[],
   oldDeck: readonly CardState[],
   cardCountMap: readonly number[][],
+  metadata: GameMetadata,
 ) {
   hands.forEach((hand) => {
     hand.forEach((order) => {
@@ -74,7 +77,7 @@ function calculatePlayerPossibilities(
       if (
         shouldCalculateCard(card, playerIndex, ourPlayerIndex, deck, oldDeck)
       ) {
-        calculateCard(card, playerIndex, ourPlayerIndex, deck, cardCountMap);
+        calculateCard(card, playerIndex, ourPlayerIndex, deck, cardCountMap, metadata);
       }
     });
   });
@@ -86,12 +89,14 @@ function calculateCard(
   ourPlayerIndex: number,
   deck: CardState[],
   cardCountMap: readonly number[][],
+  metadata: GameMetadata,
 ) {
   const deckPossibilities = generateDeckPossibilities(
     card.order,
     deck,
     playerIndex,
     ourPlayerIndex,
+    metadata
   );
   let { possibleCards, possibleCardsForEmpathy } = card;
   if (playerIndex === ourPlayerIndex) {
@@ -188,6 +193,7 @@ function generateDeckPossibilities(
   deck: readonly CardState[],
   playerIndex: number,
   ourPlayerIndex: number,
+  metadata: GameMetadata,
 ): Array<ReadonlyArray<readonly [number, number]>> {
   const deckPossibilities: Array<ReadonlyArray<readonly [number, number]>> = [];
   for (const card of deck) {
@@ -235,7 +241,25 @@ function generateDeckPossibilities(
    * applies to more than just cards that have one possibility (such as red 5 in the example).
    */
   deckPossibilities.sort((a, b) => a.length - b.length);
-  return deckPossibilities;
+  const cardCountMap = getCardCountMap(getVariant(metadata.options.variantName));
+  return deckPossibilities.filter(a => isPossibleCard(a, cardCountMap));
+}
+
+/*
+ * When we are in a hypo and morph cards, we can create impossible decks,
+ * if we do the empathy will be broken.
+ * Remove cards from possibilities that we know are from an impossible deck.
+ */
+function isPossibleCard(possibilities: ReadonlyArray<readonly [number, number]>, cardCountMap: readonly number[][]) {
+  // We know the card.
+  if(possibilities.length === 1) {
+    const [suit, rank] = possibilities[0]!;
+    cardCountMap[suit]![rank]!--;
+    if(cardCountMap[suit]![rank]! < 0){
+      return false;
+    }
+  }
+  return true;
 }
 
 function canBeUsedToDisprovePossibility(
@@ -391,8 +415,7 @@ function updatePossibilitiesToValidate(
   // eslint-disable-next-line @typescript-eslint/prefer-for-of
   for (let i = 0; i < possibilitiesToValidate.length; i++) {
     const [suit, rank] = possibilitiesToValidate[i]!;
-    // eslint-disable-next-line @typescript-eslint/no-confusing-non-null-assertion
-    if (cardCountMap[suit]![rank]! === 0) {
+    if (cardCountMap[suit]![rank]! <= 0) {
       possibilitiesToValidate[j] = [suit, rank];
       j++;
     }

--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -832,7 +832,7 @@ export default class HanabiCard
 
   private setDDA(dda: boolean) {
     const visible = this.shouldSetDDA(dda);
-    const known = this.visibleSuitIndex !== null || this.visibleRank !== null;
+    const known = this.visibleRank !== null;
     if (visible) {
       this.ddaIndicatorTop.visible(!known);
       this.ddaIndicatorBottom.visible(known);

--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -797,6 +797,12 @@ export default class HanabiCard
       return;
     }
 
+    // Don't show any status in realLifeMode.
+    if(globals.lobby.settings.realLifeMode)
+    {
+      return;
+    }
+
     let status: CardStatus;
     if (
       this.visibleSuitIndex === null ||
@@ -848,7 +854,6 @@ export default class HanabiCard
       !this.shouldShowClueBorder() &&
       this.trashcan.isVisible() === false &&
       globals.lobby.settings.hyphenatedConventions &&
-      !globals.lobby.settings.realLifeMode &&
       !globals.metadata.hardVariant
     );
   }
@@ -875,8 +880,7 @@ export default class HanabiCard
       !(globals.state.playing && this.note.blank) &&
       !(globals.state.playing && this.note.chopMoved) &&
       !variantRules.isThrowItInAHole(this.variant) &&
-      !globals.options.speedrun &&
-      !globals.lobby.settings.realLifeMode
+      !globals.options.speedrun
     );
   }
 
@@ -889,8 +893,7 @@ export default class HanabiCard
     return (
       critical &&
       !cardRules.isPlayed(this.state) &&
-      !cardRules.isDiscarded(this.state) &&
-      !globals.lobby.settings.realLifeMode
+      !cardRules.isDiscarded(this.state)
     );
   }
 

--- a/packages/client/src/game/ui/reactive/view/cardsView.ts
+++ b/packages/client/src/game/ui/reactive/view/cardsView.ts
@@ -154,6 +154,14 @@ function subscribeToCardChanges(order: number) {
     () => updatePips(order),
   );
 
+  // Status
+  sub(
+    (c) => ({
+      isKnownTrashFromEmpathy: c.isKnownTrashFromEmpathy,
+    }),
+    () => updateCardStatus(order),
+  );
+
   // Card visuals
   subFullState(
     (s) => {


### PR DESCRIPTION
If we know we have mophed cards that create an impossible deck, this will break empathy on all cards. We can remove them to make it work better.