### PR TITLE
Update Playing relationship of players not present

### DIFF
--- a/server/src/game_end.go
+++ b/server/src/game_end.go
@@ -365,6 +365,8 @@ func (t *Table) ConvertToSharedReplay(ctx context.Context, d *CommandData) {
 				logger.Info(p.Name + " was the owner of the game and they are offline; " +
 					"passing the leader to someone else.")
 			}
+			// We still need to update table relationships
+			tables.DeletePlaying(p.UserID, t.ID)
 			continue
 		}
 


### PR DESCRIPTION
Players need to be deletes from playing tabke relationship even if they are not present at the table when it terminates.

Closes #2758