### PR TITLE
Prioritize mini trash before dda

### DIFF
--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -811,11 +811,16 @@ export default class HanabiCard
 
     this.setFade(status === CardStatus.Trash);
     this.setCritical(status === CardStatus.Critical);
-    this.setDDA(this.state.inDoubleDiscard && status !== CardStatus.Critical);
-    this.setTrashMiniIndicator(
+
+    const isKnownTrash =
       !cardRules.isPlayed(this.state) &&
-        !cardRules.isDiscarded(this.state) &&
-        this.state.isKnownTrashFromEmpathy,
+      !cardRules.isDiscarded(this.state) &&
+      this.state.isKnownTrashFromEmpathy;
+    this.setTrashMiniIndicator(isKnownTrash);
+    this.setDDA(
+      this.state.inDoubleDiscard &&
+        status !== CardStatus.Critical &&
+        !isKnownTrash,
     );
   }
 


### PR DESCRIPTION
If the card is known to be trash, there is no use to view the dda icon. So we view it only if not known trash

Closes #2762