### PR TITLE
Fixes log hypo prefix

### DIFF
--- a/packages/client/src/game/reducers/stateReducer.ts
+++ b/packages/client/src/game/reducers/stateReducer.ts
@@ -278,7 +278,7 @@ function stateReducerFunction(state: Draft<State>, action: Action) {
         state.playing,
         state.shadowing,
         state.finished,
-        state.replay.hypothetical !== null,
+        false,
         state.metadata,
         state.notes.ourNotes,
       );


### PR DESCRIPTION
When a default game action is happening in stateReducer, it is never in hypo. Hypo is handeled in the replayReducer

- Closes #2757