### PR TITLE
Preserve password on remake table

### DIFF
--- a/server/src/command.go
+++ b/server/src/command.go
@@ -83,6 +83,9 @@ type CommandData struct {
 	// (e.g. the mutex lock is already acquired and does not need to be acquired again)
 	NoTableLock  bool `json:"-"` // To avoid "t.Lock()"
 	NoTablesLock bool `json:"-"` // To avoid "tables.Lock()"
+	// More remake table shenanigans
+	PasswordHash   string `json:"-"`
+	BypassPassword bool   `json:"-"`
 }
 
 var (

--- a/server/src/command_table_create.go
+++ b/server/src/command_table_create.go
@@ -132,6 +132,8 @@ func tableCreate(ctx context.Context, s *Session, d *CommandData, data *SpecialG
 		} else {
 			passwordHash = v
 		}
+	} else if d.PasswordHash != "" {
+		passwordHash = d.PasswordHash
 	}
 
 	t := NewTable(d.Name, s.UserID)
@@ -215,9 +217,10 @@ func tableCreate(ctx context.Context, s *Session, d *CommandData, data *SpecialG
 
 	// Join the user to the new table
 	commandTableJoin(ctx, s, &CommandData{ // nolint: exhaustivestruct
-		TableID:      t.ID,
-		Password:     d.Password,
-		NoTableLock:  true,
-		NoTablesLock: true,
+		TableID:        t.ID,
+		Password:       d.Password,
+		NoTableLock:    true,
+		NoTablesLock:   true,
+		BypassPassword: d.BypassPassword,
 	})
 }

--- a/server/src/command_table_join.go
+++ b/server/src/command_table_join.go
@@ -52,7 +52,7 @@ func commandTableJoin(ctx context.Context, s *Session, d *CommandData) {
 	}
 
 	// Validate that they entered the correct password
-	if t.PasswordHash != "" {
+	if t.PasswordHash != "" && !d.BypassPassword {
 		if match, err := argon2id.ComparePasswordAndHash(d.Password, t.PasswordHash); err != nil {
 			logger.Error("Failed to compare the submitted password to the Argon2 hash: " +
 				err.Error())

--- a/server/src/command_table_restart.go
+++ b/server/src/command_table_restart.go
@@ -206,6 +206,12 @@ func tableRestart(
 		newTableName = oldTableName + tableNameSuffix
 	}
 
+	// If passwordHash was nonempty, preserve old value
+	passwordHash := ""
+	if (t.PasswordHash != "") {
+		passwordHash = t.PasswordHash
+	}
+
 	// The shared replay should now be deleted, since all of the players have left
 	// Now, create the new game but hide it from the lobby
 	commandTableCreate(ctx, s, &CommandData{ // nolint: exhaustivestruct
@@ -213,9 +219,11 @@ func tableRestart(
 		Options: t.Options,
 		// If pregame option is false, then
 		// we want to prevent the pre-game from showing up in the lobby for a brief second
-		HidePregame:  d.HidePregame,
-		NoTablesLock: true,
-		MaxPlayers:   t.MaxPlayers,
+		HidePregame:    d.HidePregame,
+		NoTablesLock:   true,
+		MaxPlayers:     t.MaxPlayers,
+		PasswordHash:   passwordHash,
+		BypassPassword: true,
 	})
 
 	// Find the table ID for the new game
@@ -254,9 +262,10 @@ func tableRestart(
 			continue
 		}
 		commandTableJoin(ctx, s2, &CommandData{ // nolint: exhaustivestruct
-			TableID:      t2.ID,
-			NoTableLock:  true,
-			NoTablesLock: true,
+			TableID:        t2.ID,
+			NoTableLock:    true,
+			NoTablesLock:   true,
+			BypassPassword: true,
 		})
 	}
 


### PR DESCRIPTION
Closes #2683

I decided not to implement the thing that makes spectators join as
players because of Krycke's comment in #2683. (Indeed, seems wrong to
me in at least one case: if I'm say playing a game with some friends
that's pw-protected, and I restart the game, the random specs watching
that didn't enter a password probably shouldn't be joined.) So I'm gonna
say someone should open a new issue describing what the "correct"
behavior should be.
