### PR TITLE
Add check on number of players on game api export

### DIFF
--- a/server/src/http_export.go
+++ b/server/src/http_export.go
@@ -79,6 +79,20 @@ func httpExport(c *gin.Context) {
 		options = v
 	}
 
+	// As a sanity check, ensure that the number of game participants in the database matches the
+	// number of players that are supposed to be in the game (according to the options)
+	if len(dbPlayers) != options.NumPlayers {
+		logger.Error("There are not enough game participants for game #" + strconv.Itoa(databaseID) +
+			" in the database. (There were " + strconv.Itoa(len(dbPlayers)) +
+			" player rows and there should be " + strconv.Itoa(options.NumPlayers) + ".)")
+		http.Error(
+			w,
+			http.StatusText(http.StatusInternalServerError),
+			http.StatusInternalServerError,
+		)
+		return
+	}
+
 	// Deck specification for a particular game are not stored in the database
 	// Thus, we must recalculate the deck order based on the seed of the game
 	// Get the seed from the database


### PR DESCRIPTION
Related to issue #2831:
Export function currently reported incomplete player lists when using the export API, resulting in invalid output.
This introduces a check on the correct number of players, analogously to the check in command_replay_create.go when loading full replays from the DB.

Note that this of course does not prevent inconsistent player lists from occurring, they are just detected properly now.