### PR TITLE
Support Ctrl + left-click to open note tooltip

### DIFF
--- a/packages/client/src/game/ui/HanabiCardClick.ts
+++ b/packages/client/src/game/ui/HanabiCardClick.ts
@@ -56,6 +56,19 @@ function clickLeft(card: HanabiCard, event: MouseEvent) {
     return;
   }
 
+  // A Ctrl + left-click also opens the node tooltip, since on some mac devices, right-click is not
+  // available.
+  if (
+    event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !globals.state.finished
+  ) {
+    lastNote = "";
+    notes.openEditTooltip(card);
+  }
+
   if (
     event.ctrlKey || // No actions in this function use modifiers other than Alt
     event.shiftKey ||


### PR DESCRIPTION
One some Mac devices, right-click is not available to open the tooltip (an external mouse has to be used).
Since this is the default alternative on Mac, we should support this as well.

Also see issue #2837.