### PR TITLE
DB: Delete games upon participant deletion

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -210,7 +210,7 @@
     "pidfile",
     "pingable",
     "playerinfo",
-     "plpgsql",
+    "plpgsql",
     "pnpm",
     "pquestion",
     "prasmussen",

--- a/cspell.json
+++ b/cspell.json
@@ -210,6 +210,7 @@
     "pidfile",
     "pingable",
     "playerinfo",
+     "plpgsql",
     "pnpm",
     "pquestion",
     "prasmussen",

--- a/install/database_schema.sql
+++ b/install/database_schema.sql
@@ -167,6 +167,17 @@ CREATE TABLE game_participants (
     CONSTRAINT game_participants_unique UNIQUE (game_id, user_id)
 );
 
+CREATE FUNCTION delete_game_of_deleted_participant() RETURNS TRIGGER AS $_$
+BEGIN
+DELETE FROM games WHERE games.id = OLD.game_id;
+RETURN OLD;
+END $_$ LANGUAGE 'plpgsql';
+
+CREATE TRIGGER delete_game_upon_participant_deletion
+AFTER DELETE ON game_participants
+FOR EACH ROW
+EXECUTE PROCEDURE delete_game_of_deleted_participant();
+
 DROP TABLE IF EXISTS game_participant_notes CASCADE;
 CREATE TABLE game_participant_notes (
     game_participant_id  INTEGER   NOT NULL,


### PR DESCRIPTION
This adds a trigger to the `game_participants` table so that whenever a participant of a game is deleted
(this already automatically happens whenever a user is deleted), the corresponding game is deleted as well.

Some details:
Implementation is the same as https://stackoverflow.com/questions/30281819/postgresql-delete-trigger. I suppose because the code snippet is so short, this does not cause copyright issues. If you think so, we could e.g. put a link into the source code to StackOverflow, but I don't think it's needed.


Also, not that we could e.g. add more checks such that also after each update or insert to the game_participants table (or the games table even), we check that there is the correct number of participants in the database, but this would be more work (I currently don't know how to do it properly) and is likely not needed: I don't think that we ever insert a game into the DB without inserting its participants or just randomly add participants, unless of course there is other bugs.

This PR should fix that manual deletion of users can break the database consistency (#2831), which is probably all we want for now.