### PR TITLE
API: Add secondary sort column id to all queries

### DIFF
--- a/server/src/api_misc.go
+++ b/server/src/api_misc.go
@@ -144,8 +144,10 @@ func apiBuildSubquery(params APIQueryVars) (string, string, string, []interface{
 			` + where[:len(where)-len(" AND ")]
 	}
 
+  // Note that we order by descending id as a secondary sorting criterium.
+  // This ensures that resulting queries have deterministic order.
 	orderBy := `
-		ORDER BY ` + params.Order.Column + " " + params.Order.Value
+		ORDER BY ` + params.Order.Column + " " + params.Order.Value + ", id DESC "
 	limit := `
 		LIMIT ` + strconv.Itoa(params.Size) + `
 		OFFSET ` + strconv.Itoa(params.Page*params.Size)

--- a/server/src/api_misc.go
+++ b/server/src/api_misc.go
@@ -144,7 +144,7 @@ func apiBuildSubquery(params APIQueryVars) (string, string, string, []interface{
 			` + where[:len(where)-len(" AND ")]
 	}
 
-  // Note that we order by descending id as a secondary sorting criterium.
+  // Note that we order by descending id as a secondary sorting criterion.
   // This ensures that resulting queries have deterministic order.
 	orderBy := `
 		ORDER BY ` + params.Order.Column + " " + params.Order.Value + ", id DESC "


### PR DESCRIPTION
This ensures that whenever we query data for the API, the resulting requested sort is deterministic,
therefore yielding disjoint outputs when data is queried with limit and offset (which is done regularly for the API to keep answers at a reasonable size).

Note that even though it is weird, it is still defined to query something like `ORDER BY id ASC, id DESC` in PostgreSQL, the secondary order in that case just won't matter: The ORDER BY clause works with lexicographic order.

See issue #2842 as well.