### PR TITLE
Rework Sudoku UI

### DIFF
--- a/packages/client/src/game/reducers/gameStateReducer.ts
+++ b/packages/client/src/game/reducers/gameStateReducer.ts
@@ -8,7 +8,6 @@ import * as clueTokensRules from "../rules/clueTokens";
 import * as deckRules from "../rules/deck";
 import * as handRules from "../rules/hand";
 import * as playStacksRules from "../rules/playStacks";
-import { fillInRemainingStackStartIfUnique } from "../rules/playStacks";
 import * as textRules from "../rules/text";
 import * as variantRules from "../rules/variant";
 import { ActionDiscard, ActionPlay, GameAction } from "../types/actions";
@@ -350,8 +349,6 @@ function gameStateReducerFunction(
       state.deck,
       variant,
     );
-    const { playStackStarts } = state;
-    state.playStackStarts = fillInRemainingStackStartIfUnique(playStackStarts);
   }
 
   // Discarding or playing cards can make other card cards in that suit not playable anymore and can

--- a/packages/client/src/game/rules/playStacks.ts
+++ b/packages/client/src/game/rules/playStacks.ts
@@ -151,27 +151,3 @@ export function stackStartRank(
 
   return bottomCard.rank ?? UNKNOWN_CARD_RANK;
 }
-
-export function fillInRemainingStackStartIfUnique(
-  playStackStarts: number[],
-): number[] {
-  let sumStarts = 0;
-  let numDeterminedStarts = 0;
-  let undeterminedStack: number;
-
-  for (let i = 0; i < playStackStarts.length; i++) {
-    if (playStackStarts[i] !== UNKNOWN_CARD_RANK) {
-      sumStarts += playStackStarts[i]!;
-      numDeterminedStarts++;
-      continue;
-    }
-
-    undeterminedStack = i;
-  }
-
-  if (numDeterminedStarts === playStackStarts.length - 1) {
-    playStackStarts[undeterminedStack!] = 15 - sumStarts;
-  }
-
-  return playStackStarts;
-}

--- a/packages/client/src/game/ui/Elements.ts
+++ b/packages/client/src/game/ui/Elements.ts
@@ -33,17 +33,10 @@ export class Elements {
 
   /**
    * UI row below play stacks, usually used for information about the suits, but also for stack
-   * directions in "Up Or Down" or "Reversed" variants, and the number of played cards in "Sudoku"
-   * variants. Not initialized (and therefore fully replaced by suitLabelStackStartTexts) in
-   * "Sudoku" variants while using Keldon mode with more than 2 players, since there is no space
-   * left. Appears in the second row after the 'suitLabelStackStartTexts' if these are used.
-   */
-  suitLabelTexts: FitText[] = [];
-  /**
-   * A second UI row below the play stacks (but actually shown first if present). Only initialized
+   * directions in "Up Or Down" or "Reversed" variants as well as starting values and played cards
    * in Sudoku variants.
    */
-  suitLabelStackStartTexts: FitText[] = [];
+  suitLabelTexts: FitText[] = [];
   discardArea: Konva.Rect | null = null;
   discardStacks = new Map<Suit, CardLayout>();
   playerHands: CardLayout[] = [];

--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -8,7 +8,6 @@ import {
   UNKNOWN_CARD_RANK,
   Variant,
 } from "@hanabi/data";
-import { ReadonlyMap } from "isaacscript-common-ts";
 import Konva from "konva";
 import { initialCardState } from "../reducers/initialStates/initialCardState";
 import { noteEqual, noteHasMeaning, parseNote } from "../reducers/notesReducer";
@@ -42,15 +41,6 @@ import {
 import * as notes from "./notes";
 
 const DECK_BACK_IMAGE = "deck-back";
-
-const STACK_STRINGS_SUDOKU_KELDON_MODE = new ReadonlyMap<number, string>([
-  [0, "No card played."],
-  [1, "1 card played."],
-  [2, "2 cards played."],
-  [3, "3 cards played."],
-  [4, "4 cards played."],
-  [5, "Finished"],
-]);
 
 export class HanabiCard extends Konva.Group implements NodeWithTooltip, UICard {
   // ---------------
@@ -1412,20 +1402,6 @@ export class HanabiCard extends Konva.Group implements NodeWithTooltip, UICard {
       lines.push(
         `Deceptive: ${variant.specialRank} is touched by number ${deceptiveRank} clue.`,
       );
-    }
-    // In Sudoku variants, there is no space for a second UI row below the stacks if Keldon mode is
-    // used with more than 2 players. We put the number of played cards per stack into the hover of
-    // the stack cards.
-    if (
-      variantRules.isSudoku(variant) &&
-      globals.lobby.settings.keldonMode &&
-      globals.options.numPlayers > 2
-    ) {
-      const numPlayedCards =
-        globals.state.visibleState!.playStacks[
-          this.getCardIdentity().suitIndex!
-        ]!.length;
-      lines.push(STACK_STRINGS_SUDOKU_KELDON_MODE.get(numPlayedCards)!);
     }
     const abbreviation = abbreviationRules.get(suit.name, variant);
     return `<div style="font-size: 0.75em;"><div style="text-align: center">${

--- a/packages/client/src/game/ui/drawUI.ts
+++ b/packages/client/src/game/ui/drawUI.ts
@@ -285,33 +285,6 @@ interface PlayStackValues {
   spacing: number;
 }
 
-function createLabelTextBelowStack(
-  winHeight: number,
-  winWidth: number,
-  stackCardWidth: number,
-  text: string,
-  playStackValues: PlayStackValues,
-  index: number,
-  row: number,
-) {
-  return new FitText({
-    x:
-      (playStackValues.x -
-        0.01 +
-        (stackCardWidth + playStackValues.spacing) * index) *
-      winWidth,
-    y: (playStackValues.y + 0.155) * winHeight + row * 0.02 * winHeight,
-    width: 0.08 * winWidth,
-    height: 0.051 * winHeight,
-    fontSize: 0.02 * winHeight,
-    fontFamily: "Verdana",
-    align: "center",
-    text,
-    fill: LABEL_COLOR,
-    listening: false,
-  });
-}
-
 function drawPlayStacks() {
   let yOffset: number;
 
@@ -443,60 +416,29 @@ function drawPlayStacks() {
 
       if (variantRules.isSudoku(globals.variant)) {
         // Don't show anything here, the starting values will be written by the state observers
-        // updating when the starting value changes.
+        // updating when the starting or the played cards value changes.
         text = "";
       }
 
-      // This is the text box for the suit names or, in UpOrDown, for the stack directions.
-      let suitLabelText: FitText | undefined;
-
-      if (!globals.variant.showStackStarts) {
-        // If we don't have a second UI row (for the stack starts), this is placed directly below.
-        suitLabelText = createLabelTextBelowStack(
-          winH,
+      const suitLabelText = new FitText({
+        x:
+          (playStackValues.x -
+            0.01 +
+            (cardWidth + playStackValues.spacing) * i) *
           winW,
-          cardWidth,
-          text,
-          playStackValues,
-          i,
-          0,
-        );
-      } else {
-        // The second UI row is deactivated in Keldon mode with at least 2 players, since there is
-        // simply no space.
-        if (
-          !(globals.lobby.settings.keldonMode && globals.options.numPlayers > 2)
-        ) {
-          // If we have two UI rows, then the suit names / stack directions will be the second row.
-          suitLabelText = createLabelTextBelowStack(
-            winH,
-            winW,
-            cardWidth,
-            text,
-            playStackValues,
-            i,
-            1,
-          );
-        }
+        y: (playStackValues.y + 0.155) * winH,
+        width: 0.08 * winW,
+        height: 0.051 * winH,
+        fontSize: 0.02 * winH,
+        fontFamily: "Verdana",
+        align: "center",
+        text,
+        fill: LABEL_COLOR,
+        listening: false,
+      });
 
-        // The first row now consists of the stack starts.
-        const stackStartText = createLabelTextBelowStack(
-          winH,
-          winW,
-          cardWidth,
-          "",
-          playStackValues,
-          i,
-          0,
-        );
-        globals.layers.UI.add(stackStartText);
-        globals.elements.suitLabelStackStartTexts.push(stackStartText);
-      }
-
-      if (suitLabelText !== undefined) {
-        globals.layers.UI.add(suitLabelText);
-        globals.elements.suitLabelTexts.push(suitLabelText);
-      }
+      globals.layers.UI.add(suitLabelText);
+      globals.elements.suitLabelTexts.push(suitLabelText);
     }
   }
 

--- a/packages/client/src/game/ui/reactive/StateObserver.ts
+++ b/packages/client/src/game/ui/reactive/StateObserver.ts
@@ -193,10 +193,6 @@ const visibleStateObservers: Subscriptions = [
     cardLayoutView.onPlayStackDirectionsChanged,
   ),
 
-  // In Sudoku variants, we want to display the first rank played in each suit. This is important in
-  // order to know which ranks are still available to start the others.
-  subVS((s) => s.playStackStarts, cardLayoutView.onPlayStackStartsChanged),
-
   // Unsubscribe and reset removed cards. Must come after card layout so animations to deck are
   // correctly triggered.
   subVS((s) => s.deck.length, cardsView.onCardsPossiblyRemoved),

--- a/packages/client/src/game/ui/reactive/view/cardLayoutView.ts
+++ b/packages/client/src/game/ui/reactive/view/cardLayoutView.ts
@@ -132,7 +132,6 @@ export function onPlayStacksChanged(
 
   if (variantRules.isSudoku(globals.variant)) {
     // First, we will find out all available stack starts.
-
     const availableStackStartsFlags: boolean[] = [true, true, true, true, true];
     playStacks.forEach((playStack) => {
       const stackStart = stackStartRank(

--- a/packages/client/src/game/ui/reactive/view/cardLayoutView.ts
+++ b/packages/client/src/game/ui/reactive/view/cardLayoutView.ts
@@ -3,6 +3,7 @@ import equal from "fast-deep-equal";
 import { ReadonlyMap } from "isaacscript-common-ts";
 import Konva from "konva";
 import * as deck from "../../../rules/deck";
+import { stackStartRank } from "../../../rules/playStacks";
 import * as variantRules from "../../../rules/variant";
 import { StackDirection } from "../../../types/StackDirection";
 import { globals } from "../../globals";
@@ -22,15 +23,6 @@ const STACK_STRINGS_UP_OR_DOWN = new ReadonlyMap<StackDirection, string>([
   [StackDirection.Up, "Up"],
   [StackDirection.Down, "Down"],
   [StackDirection.Finished, "Finished"],
-]);
-
-const STACK_STRINGS_SUDOKU = new ReadonlyMap<number, string>([
-  [0, ""],
-  [1, ""],
-  [2, "2 cards played"],
-  [3, "3 cards played"],
-  [4, "4 cards played"],
-  [5, "Finished"],
 ]);
 
 export function onPlayStackDirectionsChanged(
@@ -74,29 +66,6 @@ export function onPlayStackDirectionsChanged(
     });
     globals.layers.UI.batchDraw();
   }
-}
-
-export function onPlayStackStartsChanged(
-  stackStarts: readonly number[],
-  previousStackStarts: readonly number[] | undefined,
-): void {
-  if (!variantRules.isSudoku(globals.variant)) {
-    return;
-  }
-
-  stackStarts.forEach((stackStart, i) => {
-    if (
-      previousStackStarts !== undefined &&
-      previousStackStarts[i] === stackStart
-    ) {
-      return;
-    }
-    let text = "";
-    if (stackStart !== UNKNOWN_CARD_RANK) {
-      text = `Starts at ${stackStart}`;
-    }
-    globals.elements.suitLabelStackStartTexts[i]!.fitText(text);
-  });
 }
 
 export function onHandsChanged(hands: ReadonlyArray<readonly number[]>): void {
@@ -159,21 +128,50 @@ export function onPlayStacksChanged(
       const playStack = globals.elements.playStacks.get(suit)!;
       playStack.hideCardsUnderneathTheTopCard();
     }
+  });
 
-    if (
-      variantRules.isSudoku(globals.variant) &&
-      !(globals.lobby.settings.keldonMode && globals.options.numPlayers > 2)
-    ) {
-      // Update the 'x cards played' field.
-      const text = STACK_STRINGS_SUDOKU.get(stack.length);
-      if (text === undefined) {
-        throw new Error(
-          `Failed to get the stack string for ${stack.length} card(s) played.`,
+  if (variantRules.isSudoku(globals.variant)) {
+    // First, we will find out all available stack starts.
+
+    const availableStackStartsFlags: boolean[] = [true, true, true, true, true];
+    playStacks.forEach((playStack) => {
+      const stackStart = stackStartRank(
+        playStack,
+        globals.state.visibleState!.deck,
+        globals.variant,
+      );
+      if (stackStart !== UNKNOWN_CARD_RANK) {
+        availableStackStartsFlags[stackStart - 1] = false;
+      }
+    });
+    const availableStackStarts: number[] = [];
+    availableStackStartsFlags.forEach((available, index) => {
+      if (available) {
+        availableStackStarts.push(index + 1);
+      }
+    });
+
+    // Now, add the suit label texts, showing current progress or the possible remaining starting
+    // values.
+    playStacks.forEach((stack, i) => {
+      let text = "";
+      if (stack.length === 5) {
+        text = "Finished";
+      } else if (stack.length !== 0) {
+        const stackStart = globals.deck[stack[0]!]!.visibleRank!;
+        const playedRanks = Array.from(
+          { length: stack.length },
+          (_, rankOffset) => ((rankOffset + stackStart - 1) % 5) + 1,
         );
+        text = `[ ${playedRanks.join(" ")}${Array(6 - stack.length).join(
+          " _",
+        )} ]`;
+      } else {
+        text = `Start: [${availableStackStarts.join("")}]`;
       }
       globals.elements.suitLabelTexts[i]!.fitText(text);
-    }
-  });
+    });
+  }
 
   globals.layers.card.batchDraw();
 }

--- a/packages/data/src/getVariantDescriptions.ts
+++ b/packages/data/src/getVariantDescriptions.ts
@@ -1218,7 +1218,6 @@ export function getSudokuVariants(
     name: `Sudoku (${numSuits} Suits)`,
     suits: basicVariantSuits[numSuits]!,
     showSuitNames: true,
-    showStackStarts: true,
   });
 
   // Create combinations with special suits.
@@ -1232,7 +1231,6 @@ export function getSudokuVariants(
       name: variantName,
       suits: variantSuits,
       showSuitNames: true,
-      showStackStarts: true,
     });
   }
 

--- a/packages/data/src/json/variants.json
+++ b/packages/data/src/json/variants.json
@@ -14815,140 +14815,120 @@
     "id": 2072,
     "name": "Sudoku (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Purple"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2073,
     "name": "Sudoku & Black (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Black"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2074,
     "name": "Sudoku & Rainbow (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Rainbow"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2075,
     "name": "Sudoku & Pink (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Pink"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2076,
     "name": "Sudoku & White (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "White"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2077,
     "name": "Sudoku & Brown (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Brown"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2078,
     "name": "Sudoku & Omni (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Omni"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2079,
     "name": "Sudoku & Null (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Null"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2080,
     "name": "Sudoku & Muddy Rainbow (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Muddy Rainbow"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2081,
     "name": "Sudoku & Light Pink (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Light Pink"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2082,
     "name": "Sudoku & Prism (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Prism"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2083,
     "name": "Sudoku & Dark Rainbow (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Dark Rainbow"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2084,
     "name": "Sudoku & Dark Pink (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Dark Pink"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2085,
     "name": "Sudoku & Gray (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Gray"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2086,
     "name": "Sudoku & Dark Brown (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Dark Brown"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2087,
     "name": "Sudoku & Dark Omni (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Dark Omni"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2088,
     "name": "Sudoku & Dark Null (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Dark Null"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2089,
     "name": "Sudoku & Cocoa Rainbow (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Cocoa Rainbow"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2090,
     "name": "Sudoku & Gray Pink (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Gray Pink"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   },
   {
     "id": 2091,
     "name": "Sudoku & Dark Prism (5 Suits)",
     "suits": ["Red", "Yellow", "Green", "Blue", "Dark Prism"],
-    "showSuitNames": true,
-    "showStackStarts": true
+    "showSuitNames": true
   }
 ]

--- a/packages/data/src/types/Variant.ts
+++ b/packages/data/src/types/Variant.ts
@@ -24,7 +24,6 @@ export interface Variant {
   readonly chimneys: boolean;
 
   readonly showSuitNames: boolean;
-  readonly showStackStarts: boolean;
   readonly maxScore: number;
   readonly offsetCornerElements: boolean;
   readonly suitAbbreviations: readonly string[];

--- a/packages/data/src/types/VariantDescription.ts
+++ b/packages/data/src/types/VariantDescription.ts
@@ -30,5 +30,4 @@ export interface VariantDescription {
   rankCluesTouchNothing?: boolean;
 
   showSuitNames?: boolean;
-  showStackStarts?: boolean;
 }

--- a/packages/data/src/types/VariantJSON.ts
+++ b/packages/data/src/types/VariantJSON.ts
@@ -29,5 +29,4 @@ export interface VariantJSON {
   rankCluesTouchNothing?: boolean;
 
   showSuitNames?: boolean;
-  showStackStarts?: boolean;
 }

--- a/packages/data/src/variantsInit.ts
+++ b/packages/data/src/variantsInit.ts
@@ -294,15 +294,6 @@ export function variantsInit(
       showSuitNames = true;
     }
 
-    const showStackStarts = variantJSON.showStackStarts ?? false;
-
-    // The second UI row only makes sense if we already have a first one.
-    if (showStackStarts && !showSuitNames) {
-      throw new Error(
-        "The 'showStackStarts' property can only be set to true if 'showSuitNames' is already true.",
-      );
-    }
-
     // Assume 5 cards per stack.
     const maxScore = suits.length * 5;
 
@@ -344,7 +335,6 @@ export function variantsInit(
       funnels,
       chimneys,
       showSuitNames,
-      showStackStarts,
       maxScore,
       offsetCornerElements,
       suitAbbreviations,


### PR DESCRIPTION
Fixes #2852.

In particular, gets rid of all the UI code related to the second label row below the stacks, since we don't need these anymore. Also simplifies logic, since we don't have to do anything special in Keldon mode.