### PR TITLE
Client: Sudoku: Fix UI bug showing 0 as stack start

### DIFF
--- a/packages/client/src/game/ui/reactive/view/cardLayoutView.ts
+++ b/packages/client/src/game/ui/reactive/view/cardLayoutView.ts
@@ -157,7 +157,7 @@ export function onPlayStacksChanged(
       if (stack.length === 5) {
         text = "Finished";
       } else if (stack.length !== 0) {
-        const stackStart = globals.deck[stack[0]!]!.visibleRank!;
+        const stackStart = globals.deck[stack[0]!]!.getCardIdentity().rank!;
         const playedRanks = Array.from(
           { length: stack.length },
           (_, rankOffset) => ((rankOffset + stackStart - 1) % 5) + 1,


### PR DESCRIPTION
Client sometimes showed 0 as stack start immediately after the first card of a stack played. Probably this is due to visibleRank not being updated properly before drawing the UI (the bug seems to occur a bit random), but getCardIdentity does not have this issue.

See also #2859