### PR TITLE
Clean up sudoku

### DIFF
--- a/packages/client/src/game/rules/variants/reversible.ts
+++ b/packages/client/src/game/rules/variants/reversible.ts
@@ -115,7 +115,7 @@ function isDead(
     // dead already.
     const lowestNextRank = variant.upOrDown ? 2 : 1;
     for (const nextRank of eRange(lowestNextRank, rank)) {
-      if (allDiscardedSet.has(nextRank)) {
+      if (allDiscardedSet.has(nextRank as Rank)) {
         return true;
       }
     }
@@ -127,7 +127,7 @@ function isDead(
     // The above comment also applies for `StackDirection.Down`.
     const highestNextRank = variant.upOrDown ? 4 : 5;
     for (const nextRank of eRange(highestNextRank, rank)) {
-      if (allDiscardedSet.has(nextRank)) {
+      if (allDiscardedSet.has(nextRank as Rank)) {
         return true;
       }
     }
@@ -217,7 +217,7 @@ function walkUp(allDiscardedSet: Set<Rank>, variant: Variant): number {
 
   // Second, walk upwards.
   for (const rank of iRange(2, 5)) {
-    if (allDiscardedSet.has(rank)) {
+    if (allDiscardedSet.has(rank as Rank)) {
       break;
     }
     cardsThatCanStillBePlayed++;
@@ -244,7 +244,7 @@ function walkDown(allDiscardedSet: Set<Rank>, variant: Variant) {
 
   // Second, walk downwards.
   for (const rank of iRange(4, 1)) {
-    if (allDiscardedSet.has(rank)) {
+    if (allDiscardedSet.has(rank as Rank)) {
       break;
     }
     cardsThatCanStillBePlayed++;

--- a/packages/client/src/game/rules/variants/sudoku.test.ts
+++ b/packages/client/src/game/rules/variants/sudoku.test.ts
@@ -1,0 +1,53 @@
+import { sudokuWalkUpAll, getMaxScorePerStack } from "./sudoku";
+import {Rank} from "@hanabi/data";
+
+describe("WalkUpAll", () => {
+    test("Handles single discarded 1", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([1]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0,4,3,2,1]);
+    });
+    test("Handles single discarded 2", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([2]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1,0,4,3,2]);
+    });
+    test("Handles single discarded 3", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([3]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([2,1,0,4,3]);
+    });
+    test("Handles single discarded 4", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([4]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([3,2,1,0,4]);
+    });
+    test("Handles single discarded 5", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([5]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([4,3,2,1,0]);
+    });
+    test("Handles discarded 2 and 5", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([2, 5]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1,0,2,1,0]);
+    });
+    test("Handles discarded 1 and 4", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 4]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0,2,1,0,1]);
+    });
+    test("Handles discarded 1, 2, and 5", () => {
+        const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 2, 5]);
+        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
+        expect(allMax).toBe(false);
+        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0,0,2,1,0]);
+    });
+});

--- a/packages/client/src/game/rules/variants/sudoku.test.ts
+++ b/packages/client/src/game/rules/variants/sudoku.test.ts
@@ -1,7 +1,7 @@
 import type { Rank } from "@hanabi/data";
 import { sudokuWalkUpAll } from "./sudoku";
 
-describe("WalkUpAll", () => {
+describe("sudokuWalkUpAll", () => {
   test("Handles single discarded 1", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([1]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =
@@ -9,6 +9,7 @@ describe("WalkUpAll", () => {
     expect(allMax).toBe(false);
     expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0, 4, 3, 2, 1]);
   });
+
   test("Handles single discarded 2", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([2]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =
@@ -16,6 +17,7 @@ describe("WalkUpAll", () => {
     expect(allMax).toBe(false);
     expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1, 0, 4, 3, 2]);
   });
+
   test("Handles single discarded 3", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([3]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =
@@ -23,6 +25,7 @@ describe("WalkUpAll", () => {
     expect(allMax).toBe(false);
     expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([2, 1, 0, 4, 3]);
   });
+
   test("Handles single discarded 4", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([4]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =
@@ -30,6 +33,7 @@ describe("WalkUpAll", () => {
     expect(allMax).toBe(false);
     expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([3, 2, 1, 0, 4]);
   });
+
   test("Handles single discarded 5", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([5]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =
@@ -37,6 +41,7 @@ describe("WalkUpAll", () => {
     expect(allMax).toBe(false);
     expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([4, 3, 2, 1, 0]);
   });
+
   test("Handles discarded 2 and 5", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([2, 5]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =
@@ -44,6 +49,7 @@ describe("WalkUpAll", () => {
     expect(allMax).toBe(false);
     expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1, 0, 2, 1, 0]);
   });
+
   test("Handles discarded 1 and 4", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 4]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =
@@ -51,6 +57,7 @@ describe("WalkUpAll", () => {
     expect(allMax).toBe(false);
     expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0, 2, 1, 0, 1]);
   });
+
   test("Handles discarded 1, 2, and 5", () => {
     const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 2, 5]);
     const { allMax, maxScoresForEachStartingValueOfSuit } =

--- a/packages/client/src/game/rules/variants/sudoku.test.ts
+++ b/packages/client/src/game/rules/variants/sudoku.test.ts
@@ -1,53 +1,61 @@
+import type { Rank } from "@hanabi/data";
 import { sudokuWalkUpAll } from "./sudoku";
-import type {Rank} from "@hanabi/data";
 
 describe("WalkUpAll", () => {
-    test("Handles single discarded 1", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([1]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0,4,3,2,1]);
-    });
-    test("Handles single discarded 2", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([2]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1,0,4,3,2]);
-    });
-    test("Handles single discarded 3", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([3]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([2,1,0,4,3]);
-    });
-    test("Handles single discarded 4", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([4]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([3,2,1,0,4]);
-    });
-    test("Handles single discarded 5", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([5]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([4,3,2,1,0]);
-    });
-    test("Handles discarded 2 and 5", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([2, 5]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1,0,2,1,0]);
-    });
-    test("Handles discarded 1 and 4", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 4]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0,2,1,0,1]);
-    });
-    test("Handles discarded 1, 2, and 5", () => {
-        const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 2, 5]);
-        const { allMax, maxScoresForEachStartingValueOfSuit } =  sudokuWalkUpAll(allDiscardedSet);
-        expect(allMax).toBe(false);
-        expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0,0,2,1,0]);
-    });
+  test("Handles single discarded 1", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([1]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0, 4, 3, 2, 1]);
+  });
+  test("Handles single discarded 2", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([2]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1, 0, 4, 3, 2]);
+  });
+  test("Handles single discarded 3", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([3]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([2, 1, 0, 4, 3]);
+  });
+  test("Handles single discarded 4", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([4]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([3, 2, 1, 0, 4]);
+  });
+  test("Handles single discarded 5", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([5]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([4, 3, 2, 1, 0]);
+  });
+  test("Handles discarded 2 and 5", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([2, 5]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([1, 0, 2, 1, 0]);
+  });
+  test("Handles discarded 1 and 4", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 4]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0, 2, 1, 0, 1]);
+  });
+  test("Handles discarded 1, 2, and 5", () => {
+    const allDiscardedSet: Set<Rank> = new Set<Rank>([1, 2, 5]);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
+    expect(allMax).toBe(false);
+    expect(maxScoresForEachStartingValueOfSuit).toStrictEqual([0, 0, 2, 1, 0]);
+  });
 });

--- a/packages/client/src/game/rules/variants/sudoku.test.ts
+++ b/packages/client/src/game/rules/variants/sudoku.test.ts
@@ -1,4 +1,4 @@
-import { sudokuWalkUpAll, getMaxScorePerStack } from "./sudoku";
+import { sudokuWalkUpAll } from "./sudoku";
 import {Rank} from "@hanabi/data";
 
 describe("WalkUpAll", () => {

--- a/packages/client/src/game/rules/variants/sudoku.test.ts
+++ b/packages/client/src/game/rules/variants/sudoku.test.ts
@@ -1,5 +1,5 @@
 import { sudokuWalkUpAll } from "./sudoku";
-import {Rank} from "@hanabi/data";
+import type {Rank} from "@hanabi/data";
 
 describe("WalkUpAll", () => {
     test("Handles single discarded 1", () => {

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -20,7 +20,8 @@ export function sudokuCanStillBePlayed(
   variant: Variant,
 ): boolean {
   const allDiscardedSet = getAllDiscardedSet(variant, deck, suitIndex);
-  const { maxScoresForEachStartingValueOfSuit } = sudokuWalkUpAll(allDiscardedSet);
+  const { maxScoresForEachStartingValueOfSuit } =
+    sudokuWalkUpAll(allDiscardedSet);
 
   const playStackStart = playStackStarts[suitIndex];
   assertDefined(
@@ -40,10 +41,11 @@ export function sudokuCanStillBePlayed(
     const longestSequence =
       (rank - possibleStackStartRank + DEFAULT_FINISHED_STACK_LENGTH) %
       DEFAULT_FINISHED_STACK_LENGTH;
-    const score = maxScoresForEachStartingValueOfSuit[possibleStackStartRank - 1];
+    const score =
+      maxScoresForEachStartingValueOfSuit[possibleStackStartRank - 1];
     assertDefined(
-        score,
-        `Failed to find the max score for starting suit ${suitIndex} at start ${possibleStackStartRank}`,
+      score,
+      `Failed to find the max score for starting suit ${suitIndex} at start ${possibleStackStartRank}`,
     );
     return score > longestSequence;
   });
@@ -70,7 +72,8 @@ function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
     if (allDiscardedSet.has(currentRank)) {
       // We hit a new dead rank.
       for (const writeRank of eRange(lastDead + 1, currentRank)) {
-        maxScoresForEachStartingValueOfSuit[writeRank - 1] = currentRank - writeRank;
+        maxScoresForEachStartingValueOfSuit[writeRank - 1] =
+          currentRank - writeRank;
       }
 
       maxScoresForEachStartingValueOfSuit[currentRank - 1] = 0;
@@ -110,7 +113,6 @@ function sudokuGetUnusedStackStartRanks(
   return DEFAULT_CARD_RANKS.filter((rank) => !playStackStarts.includes(rank));
 }
 
-
 type FiveStackIndex = 0 | 1 | 2 | 3 | 4;
 
 function increment_index(i: FiveStackIndex): FiveStackIndex {
@@ -134,14 +136,16 @@ function decrement_index(i: FiveStackIndex): FiveStackIndex {
  * @param start
  * @param end
  */
-function* eRange5(start: FiveStackIndex, end: FiveStackIndex): Generator<FiveStackIndex> {
-  while(start < end) {
+function* eRange5(
+  start: FiveStackIndex,
+  end: FiveStackIndex,
+): Generator<FiveStackIndex> {
+  while (start < end) {
     yield start;
     // Note this increment must be safe since start < end, so in particular, start + 1 is still at most 4
     start = increment_index(start);
   }
 }
-
 
 /**
  * This function mimics `variantSudokuGetMaxScore` from the "variants_sudoku.go" file on the server.
@@ -167,7 +171,8 @@ export function getMaxScorePerStack(
     const suitIndex = i as SuitIndex;
 
     const allDiscardedSet = getAllDiscardedSet(variant, deck, suitIndex);
-    const { allMax, maxScoresForEachStartingValueOfSuit } = sudokuWalkUpAll(allDiscardedSet);
+    const { allMax, maxScoresForEachStartingValueOfSuit } =
+      sudokuWalkUpAll(allDiscardedSet);
 
     if (allMax) {
       independentPartOfMaxScore[suitIndex] = DEFAULT_FINISHED_STACK_LENGTH;
@@ -177,9 +182,9 @@ export function getMaxScorePerStack(
     if (stackStart !== null) {
       const score = maxScoresForEachStartingValueOfSuit[stackStart - 1];
       assertDefined(
-          score,
-          `Failed to find the max score for starting suit ${suitIndex} at start ${stackStart}`,
-      )
+        score,
+        `Failed to find the max score for starting suit ${suitIndex} at start ${stackStart}`,
+      );
       independentPartOfMaxScore[suitIndex] = score;
       continue;
     }
@@ -206,11 +211,17 @@ export function getMaxScorePerStack(
 
   // This will denote a 'local' index and refers to the index in the unassignedSuits array.
   // We will therefore iterate this over 0, ..., unassignedSuits.length - 1
-  let localSuitIndex: FiveStackIndex =  0;
+  let localSuitIndex: FiveStackIndex = 0;
 
   // A map (unassignedSuits) -> (index in possibleStackStarts) that denotes the current assignment of the stacks
   // to their starting values. We use local suit indices to access into this.
-  const curAssignment: Tuple<FiveStackIndex | undefined, 5> = [undefined, undefined, undefined, undefined, undefined];
+  const curAssignment: Tuple<FiveStackIndex | undefined, 5> = [
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ];
 
   // A map (index of stackStart) -> bool, denoting wether some suit is currently assigned to this
   // stack start
@@ -225,10 +236,13 @@ export function getMaxScorePerStack(
     let couldIncrement = false;
     if (curAssignedStackStartIndex != 4) {
       const first_try =
-          curAssignedStackStartIndex == undefined
-              ? 0
-              : increment_index(curAssignedStackStartIndex);
-      for (const nextAssignment of eRange5(first_try, possibleStackStarts.length as FiveStackIndex)) {
+        curAssignedStackStartIndex == undefined
+          ? 0
+          : increment_index(curAssignedStackStartIndex);
+      for (const nextAssignment of eRange5(
+        first_try,
+        possibleStackStarts.length as FiveStackIndex,
+      )) {
         if (!assigned[nextAssignment]) {
           curAssignment[localSuitIndex] = nextAssignment;
           assigned[nextAssignment] = true;
@@ -248,22 +262,38 @@ export function getMaxScorePerStack(
           assignedStackStartIndex,
         ] of curAssignment.entries()) {
           if (assignedLocalSuitIndex < unassignedSuits.length) {
-            assertDefined(assignedStackStartIndex, "Unexpected undefined assignment when trying to evaluate full assignment");
+            assertDefined(
+              assignedStackStartIndex,
+              "Unexpected undefined assignment when trying to evaluate full assignment",
+            );
 
             const assignedSuit = unassignedSuits[assignedLocalSuitIndex];
-            const assignedStackStart = possibleStackStarts[assignedStackStartIndex];
+            const assignedStackStart =
+              possibleStackStarts[assignedStackStartIndex];
 
             // This hould be redundant, because we already checked that assignedLocalSuitIndex is not too big in the if condition,
             // but the compiler cannot automatically deduce thas.
-            assertDefined(assignedSuit, "Implementation error: Array access undefined after range check.");
-            assertDefined(assignedStackStart, "Failed to retrieve stack start while solving assignment Problem: Index access out of range");
+            assertDefined(
+              assignedSuit,
+              "Implementation error: Array access undefined after range check.",
+            );
+            assertDefined(
+              assignedStackStart,
+              "Failed to retrieve stack start while solving assignment Problem: Index access out of range",
+            );
 
             const maxPartialScoresForThisSuit = maxPartialScores[assignedSuit];
-            assertDefined(maxPartialScoresForThisSuit, `Failed to retrieve max partial scores for suit ${assignedSuit}`);
+            assertDefined(
+              maxPartialScoresForThisSuit,
+              `Failed to retrieve max partial scores for suit ${assignedSuit}`,
+            );
 
             // Note the '-1' here, since the array access starts at 0, while the assigned ranks start at 1
             const value = maxPartialScoresForThisSuit[assignedStackStart - 1];
-            assertDefined(value, `Failed to retrieve max score if starting suit ${assignedSuit} at rank ${assignedStackStart}`);
+            assertDefined(
+              value,
+              `Failed to retrieve max score if starting suit ${assignedSuit} at rank ${assignedStackStart}`,
+            );
             assignmentVal += value;
             assignment[assignedLocalSuitIndex] = value;
           }
@@ -282,7 +312,10 @@ export function getMaxScorePerStack(
           // smaller.
           for (const [i, val] of assignmentSorted.entries()) {
             const valBestAssignment = bestAssignmentSorted[i];
-            assertDefined(valBestAssignment, "Failed to retrieve currently best stored assignment entry.");
+            assertDefined(
+              valBestAssignment,
+              "Failed to retrieve currently best stored assignment entry.",
+            );
             if (val < valBestAssignment) {
               bestAssignment = assignment;
               bestAssignmentSorted = assignmentSorted;
@@ -294,7 +327,10 @@ export function getMaxScorePerStack(
 
       if (localSuitIndex < unassignedSuits.length - 1) {
         // Reset all assignment of the higher-indexed suits.
-        for (const higherLocalSuitIndex of eRange5(increment_index(localSuitIndex), unassignedSuits.length as FiveStackIndex)) {
+        for (const higherLocalSuitIndex of eRange5(
+          increment_index(localSuitIndex),
+          unassignedSuits.length as FiveStackIndex,
+        )) {
           const assignment = curAssignment[higherLocalSuitIndex];
           if (assignment !== undefined) {
             assigned[assignment] = false;

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -187,13 +187,13 @@ function evaluateAssignment(
       );
       assertDefined(
         assignedStackStart,
-        "Failed to retrieve stack start while solving assignment Problem: Index access out of range",
+        "Failed to retrieve the stack start while solving the assignment problem since the index access was out of range.",
       );
 
       const maxPartialScoresForThisSuit = maxPartialScores[assignedSuit];
       assertDefined(
         maxPartialScoresForThisSuit,
-        `Failed to retrieve max partial scores for suit ${assignedSuit}`,
+        `Failed to retrieve the max partial scores for suit: ${assignedSuit}`,
       );
 
       // Note the '-1' here, since the array access starts at 0, while the assigned ranks start at
@@ -201,7 +201,7 @@ function evaluateAssignment(
       const value = maxPartialScoresForThisSuit[assignedStackStart - 1];
       assertDefined(
         value,
-        `Failed to retrieve max score if starting suit ${assignedSuit} at rank ${assignedStackStart}`,
+        `Failed to retrieve the max score for starting suit ${assignedSuit} at rank ${assignedStackStart}.`,
       );
       assignmentValue += value;
       assignment[assignedLocalSuitIndex] = value;
@@ -236,7 +236,7 @@ function isAssignmentBetter(
       const valBestAssignment = bestAssignmentSorted[i];
       assertDefined(
         valBestAssignment,
-        "Failed to retrieve currently best stored assignment entry.",
+        "Failed to retrieve the currently best stored assignment entry.",
       );
       if (val < valBestAssignment) {
         return true;
@@ -308,7 +308,7 @@ export function getMaxScorePerStack(
       const score = maxScoresForEachStartingValueOfSuit[stackStart - 1];
       assertDefined(
         score,
-        `Failed to find the max score for starting suit ${suitIndex} at start ${stackStart}`,
+        `Failed to find the max score for the starting suit index ${suitIndex} at start: ${stackStart}`,
       );
       independentPartOfMaxScore[suitIndex] = score;
       continue;

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -20,7 +20,7 @@ export function sudokuCanStillBePlayed(
   variant: Variant,
 ): boolean {
   const allDiscardedSet = getAllDiscardedSet(variant, deck, suitIndex);
-  const { suitMaxScores } = sudokuWalkUpAll(allDiscardedSet);
+  const { maxScoresForEachStartingValueOfSuit } = sudokuWalkUpAll(allDiscardedSet);
 
   const playStackStart = playStackStarts[suitIndex];
   assertDefined(
@@ -40,7 +40,7 @@ export function sudokuCanStillBePlayed(
     const longestSequence =
       (rank - possibleStackStartRank + DEFAULT_FINISHED_STACK_LENGTH) %
       DEFAULT_FINISHED_STACK_LENGTH;
-    return suitMaxScores[possibleStackStartRank - 1]! > longestSequence;
+    return maxScoresForEachStartingValueOfSuit[possibleStackStartRank - 1]! > longestSequence;
   });
 }
 
@@ -53,9 +53,9 @@ export function sudokuCanStillBePlayed(
  */
 function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
   allMax: boolean;
-  suitMaxScores: Tuple<number, NumSuits>;
+  maxScoresForEachStartingValueOfSuit: Tuple<number, NumSuits>;
 } {
-  const suitMaxScores = newArray(
+  const maxScoresForEachStartingValueOfSuit = newArray(
     NUM_SUITS_SUDOKU,
     DEFAULT_FINISHED_STACK_LENGTH,
   ) as Tuple<number, NumSuits>;
@@ -65,10 +65,10 @@ function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
     if (allDiscardedSet.has(currentRank)) {
       // We hit a new dead rank.
       for (const writeRank of eRange(lastDead + 1, currentRank)) {
-        suitMaxScores[writeRank - 1] = currentRank - writeRank;
+        maxScoresForEachStartingValueOfSuit[writeRank - 1] = currentRank - writeRank;
       }
 
-      suitMaxScores[currentRank - 1] = 0;
+      maxScoresForEachStartingValueOfSuit[currentRank - 1] = 0;
       lastDead = currentRank;
     }
   }
@@ -77,22 +77,22 @@ function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
   if (lastDead === 0) {
     return {
       allMax: true,
-      suitMaxScores,
+      maxScoresForEachStartingValueOfSuit: maxScoresForEachStartingValueOfSuit,
     };
   }
 
   // Here, we still need to write all "higher" values, adding the longest sequence starting at 1 to
   // them.
   for (const writeRank of iRange(lastDead + 1, 5)) {
-    suitMaxScores[writeRank - 1] = Math.min(
-      suitMaxScores[0]! + 6 - writeRank,
+    maxScoresForEachStartingValueOfSuit[writeRank - 1] = Math.min(
+      maxScoresForEachStartingValueOfSuit[0]! + 6 - writeRank,
       DEFAULT_CARD_RANKS.length,
     );
   }
 
   return {
     allMax: false,
-    suitMaxScores,
+    maxScoresForEachStartingValueOfSuit: maxScoresForEachStartingValueOfSuit,
   };
 }
 
@@ -129,7 +129,7 @@ export function getMaxScorePerStack(
     const suitIndex = i as SuitIndex;
 
     const allDiscardedSet = getAllDiscardedSet(variant, deck, suitIndex);
-    const { allMax, suitMaxScores } = sudokuWalkUpAll(allDiscardedSet);
+    const { allMax, maxScoresForEachStartingValueOfSuit } = sudokuWalkUpAll(allDiscardedSet);
 
     if (allMax) {
       independentPartOfMaxScore[suitIndex] = DEFAULT_FINISHED_STACK_LENGTH;
@@ -137,11 +137,11 @@ export function getMaxScorePerStack(
     }
 
     if (stackStart !== null) {
-      independentPartOfMaxScore[suitIndex] = suitMaxScores[stackStart - 1]!;
+      independentPartOfMaxScore[suitIndex] = maxScoresForEachStartingValueOfSuit[stackStart - 1]!;
       continue;
     }
 
-    maxPartialScores[suitIndex] = suitMaxScores;
+    maxPartialScores[suitIndex] = maxScoresForEachStartingValueOfSuit;
     unassignedSuits.push(suitIndex);
   }
 

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -170,42 +170,40 @@ function evaluateAssignment(
     assignedLocalSuitIndex,
     assignedStackStartIndex,
   ] of curAssignment.entries()) {
-    if (assignedLocalSuitIndex < unassignedSuits.length) {
-      assertDefined(
-        assignedStackStartIndex,
-        "Unexpected undefined assignment when trying to evaluate the full assignment.",
-      );
+    assertDefined(
+      assignedStackStartIndex,
+      "Unexpected undefined assignment when trying to evaluate the full assignment.",
+    );
 
-      const assignedSuit = unassignedSuits[assignedLocalSuitIndex];
-      const assignedStackStart = possibleStackStarts[assignedStackStartIndex];
-
-      // This should be redundant, because we already checked that assignedLocalSuitIndex is not too
-      // big in the if condition, but the compiler cannot automatically deduce this.
-      assertDefined(
-        assignedSuit,
-        "Implementation error: Array access undefined after range check.",
-      );
-      assertDefined(
-        assignedStackStart,
-        "Failed to retrieve the stack start while solving the assignment problem since the index access was out of range.",
-      );
-
-      const maxPartialScoresForThisSuit = maxPartialScores[assignedSuit];
-      assertDefined(
-        maxPartialScoresForThisSuit,
-        `Failed to retrieve the max partial scores for suit: ${assignedSuit}`,
-      );
-
-      // Note the '-1' here, since the array access starts at 0, while the assigned ranks start at
-      // 1.
-      const value = maxPartialScoresForThisSuit[assignedStackStart - 1];
-      assertDefined(
-        value,
-        `Failed to retrieve the max score for starting suit ${assignedSuit} at rank ${assignedStackStart}.`,
-      );
-      assignmentValue += value;
-      assignment[assignedLocalSuitIndex] = value;
+    const assignedSuit = unassignedSuits[assignedLocalSuitIndex];
+    // Note that since the 'curAssignment' always has length 5, but potentially we are dealing with
+    // fewer suits, it is expected that this can be undefined (because we never assigned the other
+    // suits), so we don't throw an error here but just stop the loop.
+    if (assignedSuit === undefined) {
+      break;
     }
+
+    const assignedStackStart = possibleStackStarts[assignedStackStartIndex];
+
+    assertDefined(
+      assignedStackStart,
+      "Failed to retrieve the stack start while solving the assignment problem since the index access was out of range.",
+    );
+
+    const maxPartialScoresForThisSuit = maxPartialScores[assignedSuit];
+    assertDefined(
+      maxPartialScoresForThisSuit,
+      `Failed to retrieve the max partial scores for suit: ${assignedSuit}`,
+    );
+
+    // Note the '-1' here, since the array access starts at 0, while the assigned ranks start at 1.
+    const value = maxPartialScoresForThisSuit[assignedStackStart - 1];
+    assertDefined(
+      value,
+      `Failed to retrieve the max score for starting suit ${assignedSuit} at rank ${assignedStackStart}.`,
+    );
+    assignmentValue += value;
+    assignment[assignedLocalSuitIndex] = value;
   }
 
   return { assignmentValue, assignment };

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -85,7 +85,7 @@ function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
   if (lastDead === 0) {
     return {
       allMax: true,
-      maxScoresForEachStartingValueOfSuit: maxScoresForEachStartingValueOfSuit,
+      maxScoresForEachStartingValueOfSuit,
     };
   }
 
@@ -100,7 +100,7 @@ function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
 
   return {
     allMax: false,
-    maxScoresForEachStartingValueOfSuit: maxScoresForEachStartingValueOfSuit,
+    maxScoresForEachStartingValueOfSuit,
   };
 }
 
@@ -115,7 +115,7 @@ function sudokuGetUnusedStackStartRanks(
 
 type FiveStackIndex = 0 | 1 | 2 | 3 | 4;
 
-function increment_index(i: FiveStackIndex): FiveStackIndex {
+function incrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
   const val = i + 1;
   if (val > 5) {
     throw new TypeError("Incrementing FiveStackIndex out of range");
@@ -123,7 +123,7 @@ function increment_index(i: FiveStackIndex): FiveStackIndex {
   return val as FiveStackIndex;
 }
 
-function decrement_index(i: FiveStackIndex): FiveStackIndex {
+function decrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
   const val = i - 1;
   if (val < 5) {
     throw new TypeError("Decrementing FiveStackIndex out of range");
@@ -132,18 +132,21 @@ function decrement_index(i: FiveStackIndex): FiveStackIndex {
 }
 
 /**
- * Helper function for an iterator to range [start, end), typesafe for FiveStackIndex
- * @param start
- * @param end
+ * Helper function for an iterator to range [start, end), typesafe for FiveStackIndex.
+ *
+ * @param start First value in range.
+ * @param end First value not in range.
  */
 function* eRange5(
   start: FiveStackIndex,
   end: FiveStackIndex,
 ): Generator<FiveStackIndex> {
-  while (start < end) {
-    yield start;
-    // Note this increment must be safe since start < end, so in particular, start + 1 is still at most 4
-    start = increment_index(start);
+  let cur = start;
+  while (cur < end) {
+    yield cur;
+    // Note this increment must be safe since start < end, so in particular, start + 1 is still at
+    // most 4.
+    cur = incrementFiveStackIndex(cur);
   }
 }
 
@@ -209,12 +212,12 @@ export function getMaxScorePerStack(
   // Same, but sorted in ascending order.
   let bestAssignmentSorted: number[] = [];
 
-  // This will denote a 'local' index and refers to the index in the unassignedSuits array.
-  // We will therefore iterate this over 0, ..., unassignedSuits.length - 1
+  // This will denote a 'local' index and refers to the index in the unassignedSuits array. We will
+  // therefore iterate this over 0, ..., unassignedSuits.length - 1.
   let localSuitIndex: FiveStackIndex = 0;
 
-  // A map (unassignedSuits) -> (index in possibleStackStarts) that denotes the current assignment of the stacks
-  // to their starting values. We use local suit indices to access into this.
+  // A map (unassignedSuits) -> (index in possibleStackStarts) that denotes the current assignment
+  // of the stacks to their starting values. We use local suit indices to access into this.
   const curAssignment: Tuple<FiveStackIndex | undefined, 5> = [
     undefined,
     undefined,
@@ -224,7 +227,7 @@ export function getMaxScorePerStack(
   ];
 
   // A map (index of stackStart) -> bool, denoting wether some suit is currently assigned to this
-  // stack start
+  // stack start.
   const assigned: Tuple<boolean, 5> = [false, false, false, false, false];
 
   while (localSuitIndex >= 0) {
@@ -234,13 +237,13 @@ export function getMaxScorePerStack(
     }
 
     let couldIncrement = false;
-    if (curAssignedStackStartIndex != 4) {
-      const first_try =
-        curAssignedStackStartIndex == undefined
+    if (curAssignedStackStartIndex !== 4) {
+      const firstTry =
+        curAssignedStackStartIndex === undefined
           ? 0
-          : increment_index(curAssignedStackStartIndex);
+          : incrementFiveStackIndex(curAssignedStackStartIndex);
       for (const nextAssignment of eRange5(
-        first_try,
+        firstTry,
         possibleStackStarts.length as FiveStackIndex,
       )) {
         if (!assigned[nextAssignment]) {
@@ -271,8 +274,8 @@ export function getMaxScorePerStack(
             const assignedStackStart =
               possibleStackStarts[assignedStackStartIndex];
 
-            // This hould be redundant, because we already checked that assignedLocalSuitIndex is not too big in the if condition,
-            // but the compiler cannot automatically deduce thas.
+            // This hould be redundant, because we already checked that assignedLocalSuitIndex is
+            // not too big in the if condition, but the compiler cannot automatically deduce thas.
             assertDefined(
               assignedSuit,
               "Implementation error: Array access undefined after range check.",
@@ -288,7 +291,8 @@ export function getMaxScorePerStack(
               `Failed to retrieve max partial scores for suit ${assignedSuit}`,
             );
 
-            // Note the '-1' here, since the array access starts at 0, while the assigned ranks start at 1
+            // Note the '-1' here, since the array access starts at 0, while the assigned ranks
+            // start at 1.
             const value = maxPartialScoresForThisSuit[assignedStackStart - 1];
             assertDefined(
               value,
@@ -328,7 +332,7 @@ export function getMaxScorePerStack(
       if (localSuitIndex < unassignedSuits.length - 1) {
         // Reset all assignment of the higher-indexed suits.
         for (const higherLocalSuitIndex of eRange5(
-          increment_index(localSuitIndex),
+          incrementFiveStackIndex(localSuitIndex),
           unassignedSuits.length as FiveStackIndex,
         )) {
           const assignment = curAssignment[higherLocalSuitIndex];
@@ -337,10 +341,10 @@ export function getMaxScorePerStack(
           }
           curAssignment[higherLocalSuitIndex] = undefined;
         }
-        localSuitIndex = increment_index(localSuitIndex);
+        localSuitIndex = incrementFiveStackIndex(localSuitIndex);
       }
     } else {
-      localSuitIndex = decrement_index(localSuitIndex);
+      localSuitIndex = decrementFiveStackIndex(localSuitIndex);
     }
   }
 

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -89,13 +89,18 @@ function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
     };
   }
 
-  // Here, we still need to write all "higher" values, adding the longest sequence starting at 1 to
-  // them.
-  for (const writeRank of iRange(lastDead + 1, 5)) {
-    maxScoresForEachStartingValueOfSuit[writeRank - 1] = Math.min(
-      maxScoresForEachStartingValueOfSuit[0]! + 6 - writeRank,
-      DEFAULT_CARD_RANKS.length,
-    );
+  if (lastDead != 5) {
+    // Here, we still need to write all "higher" values, adding the longest sequence starting at 1 to
+    // them.
+    for (const writeRank of iRange(lastDead + 1, 5)) {
+      maxScoresForEachStartingValueOfSuit[writeRank - 1] = Math.min(
+        maxScoresForEachStartingValueOfSuit[0]! + 6 - writeRank,
+        DEFAULT_CARD_RANKS.length,
+      );
+    }
+  }
+
+  if (maxScoresForEachStartingValueOfSuit.length != 5) {
   }
 
   return {
@@ -125,7 +130,7 @@ function incrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
 
 function decrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
   const val = i - 1;
-  if (val < 5) {
+  if (val < 0) {
     throw new TypeError("Decrementing FiveStackIndex out of range");
   }
   return val as FiveStackIndex;
@@ -230,7 +235,7 @@ export function getMaxScorePerStack(
   // stack start.
   const assigned: Tuple<boolean, 5> = [false, false, false, false, false];
 
-  while (localSuitIndex >= 0) {
+  while (true) {
     const curAssignedStackStartIndex = curAssignment[localSuitIndex];
     if (curAssignedStackStartIndex !== undefined) {
       assigned[curAssignedStackStartIndex] = false;
@@ -344,7 +349,11 @@ export function getMaxScorePerStack(
         localSuitIndex = incrementFiveStackIndex(localSuitIndex);
       }
     } else {
-      localSuitIndex = decrementFiveStackIndex(localSuitIndex);
+      if (localSuitIndex > 0) {
+        localSuitIndex = decrementFiveStackIndex(localSuitIndex);
+      } else {
+        break;
+      }
     }
   }
 

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -161,6 +161,7 @@ function evaluateAssignment(
 } {
   let assignmentValue = 0;
   const assignment: number[] = [];
+
   for (const [
     assignedLocalSuitIndex,
     assignedStackStartIndex,
@@ -202,6 +203,7 @@ function evaluateAssignment(
       assignment[assignedLocalSuitIndex] = value;
     }
   }
+
   return { assignmentValue, assignment };
 }
 
@@ -223,6 +225,7 @@ function isAssignmentBetter(
   if (assignmentValue > bestAssignmentSum) {
     return true;
   }
+
   if (assignmentValue === bestAssignmentSum) {
     // If the values are the same, we want to update if the assignment is lexicographically smaller.
     for (const [i, val] of assignmentSorted.entries()) {
@@ -236,6 +239,7 @@ function isAssignmentBetter(
       }
     }
   }
+
   return false;
 }
 
@@ -260,6 +264,7 @@ function findNextAssignment(
       }
     }
   }
+
   return undefined;
 }
 
@@ -346,7 +351,8 @@ export function getMaxScorePerStack(
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
   while (true) {
     // The goal of each iteration is to increase the assignment of 'localSuitIndex' to the next free
-    // stack start (= available and not yet assigned to some other suit).
+    // stack start. (Specifically, the next number available and not yet assigned to some other
+    // suit.)
 
     // Thus, we will first un-assign the current suit.
     const curAssignedStackStartIndex = curAssignment[localSuitIndex];

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -162,7 +162,7 @@ function evaluateAssignment(
   assignment: number[];
 } {
   let assignmentValue = 0;
-  let assignment: number[] = [];
+  const assignment: number[] = [];
   for (const [
     assignedLocalSuitIndex,
     assignedStackStartIndex,
@@ -176,8 +176,8 @@ function evaluateAssignment(
       const assignedSuit = unassignedSuits[assignedLocalSuitIndex];
       const assignedStackStart = possibleStackStarts[assignedStackStartIndex];
 
-      // This should be redundant, because we already checked that assignedLocalSuitIndex is
-      // not too big in the if condition, but the compiler cannot automatically deduce this.
+      // This should be redundant, because we already checked that assignedLocalSuitIndex is not too
+      // big in the if condition, but the compiler cannot automatically deduce this.
       assertDefined(
         assignedSuit,
         "Implementation error: Array access undefined after range check.",
@@ -193,8 +193,8 @@ function evaluateAssignment(
         `Failed to retrieve max partial scores for suit ${assignedSuit}`,
       );
 
-      // Note the '-1' here, since the array access starts at 0, while the assigned ranks
-      // start at 1.
+      // Note the '-1' here, since the array access starts at 0, while the assigned ranks start at
+      // 1.
       const value = maxPartialScoresForThisSuit[assignedStackStart - 1];
       assertDefined(
         value,
@@ -208,13 +208,13 @@ function evaluateAssignment(
 }
 
 /**
- * Whether the assignment is better than the previously known best, i.e. either
- * - Has a higher maximum score
- * - Has the same score, but is lexicographically smaller
- * @param assignmentValue Value of new assignment
- * @param assignmentSorted New assignment, sorted in ascending order
- * @param bestAssignmentSum Value of the currently best-known assignment
- * @param bestAssignmentSorted Currently best-known assignment, sorted in ascending order
+ * Whether the assignment is better than the previously known best, i.e. has a higher maximum score
+ * or has the same score, but is lexicographically smaller.
+ *
+ * @param assignmentValue Value of new assignment.
+ * @param assignmentSorted New assignment, sorted in ascending order.
+ * @param bestAssignmentSum Value of the currently best-known assignment.
+ * @param bestAssignmentSorted Currently best-known assignment, sorted in ascending order.
  */
 function isAssignmentBetter(
   assignmentValue: number,
@@ -224,9 +224,9 @@ function isAssignmentBetter(
 ): boolean {
   if (assignmentValue > bestAssignmentSum) {
     return true;
-  } else if (assignmentValue === bestAssignmentSum) {
-    // If the values are the same, we want to update if the assignment is lexicographically
-    // smaller.
+  }
+  if (assignmentValue === bestAssignmentSum) {
+    // If the values are the same, we want to update if the assignment is lexicographically smaller.
     for (const [i, val] of assignmentSorted.entries()) {
       const valBestAssignment = bestAssignmentSorted[i];
       assertDefined(
@@ -345,6 +345,7 @@ export function getMaxScorePerStack(
   // stack start.
   const assigned: Tuple<boolean, 5> = [false, false, false, false, false];
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
   while (true) {
     // The goal of each iteration is to increase the assignment of 'localSuitIndex' to the next free
     // stack start (= available and not yet assigned to some other suit).
@@ -355,7 +356,7 @@ export function getMaxScorePerStack(
       assigned[curAssignedStackStartIndex] = false;
     }
 
-    let nextAssignment = findNextAssignment(
+    const nextAssignment = findNextAssignment(
       curAssignedStackStartIndex,
       possibleStackStarts,
       assigned,
@@ -366,9 +367,9 @@ export function getMaxScorePerStack(
       curAssignment[localSuitIndex] = nextAssignment;
       assigned[nextAssignment] = true;
 
-      // If this was a full assignment, we need to check wether it was better
+      // If this was a full assignment, we need to check whether it was better.
       if (localSuitIndex === unassignedSuits.length - 1) {
-        let { assignmentValue, assignment } = evaluateAssignment(
+        const { assignmentValue, assignment } = evaluateAssignment(
           curAssignment,
           unassignedSuits,
           possibleStackStarts,

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -58,7 +58,7 @@ export function sudokuCanStillBePlayed(
  * returned array is [5, 5, 5, 5, 5]. This functions mimics the method `sudokuWalkUpAll` from the
  * server file "variants_sudoku.go".
  */
-function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
+export function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
   allMax: boolean;
   maxScoresForEachStartingValueOfSuit: Tuple<number, Rank>;
 } {

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -89,18 +89,15 @@ function sudokuWalkUpAll(allDiscardedSet: Set<Rank>): {
     };
   }
 
-  if (lastDead != 5) {
-    // Here, we still need to write all "higher" values, adding the longest sequence starting at 1 to
-    // them.
+  if (lastDead !== 5) {
+    // Here, we still need to write all "higher" values, adding the longest sequence starting at 1
+    // to them.
     for (const writeRank of iRange(lastDead + 1, 5)) {
       maxScoresForEachStartingValueOfSuit[writeRank - 1] = Math.min(
         maxScoresForEachStartingValueOfSuit[0]! + 6 - writeRank,
         DEFAULT_CARD_RANKS.length,
       );
     }
-  }
-
-  if (maxScoresForEachStartingValueOfSuit.length != 5) {
   }
 
   return {
@@ -348,12 +345,10 @@ export function getMaxScorePerStack(
         }
         localSuitIndex = incrementFiveStackIndex(localSuitIndex);
       }
+    } else if (localSuitIndex > 0) {
+      localSuitIndex = decrementFiveStackIndex(localSuitIndex);
     } else {
-      if (localSuitIndex > 0) {
-        localSuitIndex = decrementFiveStackIndex(localSuitIndex);
-      } else {
-        break;
-      }
+      break;
     }
   }
 

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -119,7 +119,7 @@ type FiveStackIndex = 0 | 1 | 2 | 3 | 4;
 
 function incrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
   const val = i + 1;
-  if (val > 5) {
+  if (val < 0 || val > 5) {
     throw new TypeError("Incrementing FiveStackIndex out of range");
   }
   return val as FiveStackIndex;
@@ -127,17 +127,15 @@ function incrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
 
 function decrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
   const val = i - 1;
-  if (val < 0) {
+  if (val < 0 || val > 5) {
     throw new TypeError("Decrementing FiveStackIndex out of range");
   }
   return val as FiveStackIndex;
 }
 
 /**
- * Helper function for an iterator to range [start, end), type-safe for `FiveStackIndex`.
- *
- * @param start First value in range.
- * @param end First value not in range.
+ * This is a more specialized version of `eRange` that only works with `FiveStackIndex`. (See the
+ * documentation for the `eRange` function.)
  */
 function* eRange5(
   start: FiveStackIndex,

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -119,18 +119,20 @@ type FiveStackIndex = 0 | 1 | 2 | 3 | 4;
 
 function incrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
   const val = i + 1;
-  if (val < 0 || val > 5) {
-    throw new TypeError("Incrementing FiveStackIndex out of range");
-  }
-  return val as FiveStackIndex;
+  assertFiveStackIndex(val);
+  return val;
 }
 
 function decrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
   const val = i - 1;
-  if (val < 0 || val > 5) {
-    throw new TypeError("Decrementing FiveStackIndex out of range");
+  assertFiveStackIndex(val);
+  return val;
+}
+
+function assertFiveStackIndex(val: number): asserts val is FiveStackIndex {
+  if (val < 0 || val > 4) {
+    throw new TypeError(`A FiveStackIndex must be between 0 and 4: ${val}`);
   }
-  return val as FiveStackIndex;
 }
 
 /**

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -45,7 +45,7 @@ export function sudokuCanStillBePlayed(
       maxScoresForEachStartingValueOfSuit[possibleStackStartRank - 1];
     assertDefined(
       score,
-      `Failed to find the max score for starting suit ${suitIndex} at start ${possibleStackStartRank}`,
+      `Failed to find the max score for starting suit index ${suitIndex} at start rank: ${possibleStackStartRank}`,
     );
     return score > longestSequence;
   });
@@ -131,7 +131,9 @@ function decrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
 
 function assertFiveStackIndex(val: number): asserts val is FiveStackIndex {
   if (val < 0 || val > 4) {
-    throw new TypeError(`A FiveStackIndex must be between 0 and 4: ${val}`);
+    throw new TypeError(
+      `A FiveStackIndex was ${val}, but it must be between 0 and 4.`,
+    );
   }
 }
 
@@ -171,7 +173,7 @@ function evaluateAssignment(
     if (assignedLocalSuitIndex < unassignedSuits.length) {
       assertDefined(
         assignedStackStartIndex,
-        "Unexpected undefined assignment when trying to evaluate full assignment",
+        "Unexpected undefined assignment when trying to evaluate the full assignment.",
       );
 
       const assignedSuit = unassignedSuits[assignedLocalSuitIndex];

--- a/packages/client/src/game/rules/variants/sudoku.ts
+++ b/packages/client/src/game/rules/variants/sudoku.ts
@@ -134,7 +134,7 @@ function decrementFiveStackIndex(i: FiveStackIndex): FiveStackIndex {
 }
 
 /**
- * Helper function for an iterator to range [start, end), typesafe for FiveStackIndex.
+ * Helper function for an iterator to range [start, end), type-safe for `FiveStackIndex`.
  *
  * @param start First value in range.
  * @param end First value not in range.
@@ -276,8 +276,8 @@ export function getMaxScorePerStack(
             const assignedStackStart =
               possibleStackStarts[assignedStackStartIndex];
 
-            // This hould be redundant, because we already checked that assignedLocalSuitIndex is
-            // not too big in the if condition, but the compiler cannot automatically deduce thas.
+            // This should be redundant, because we already checked that assignedLocalSuitIndex is
+            // not too big in the if condition, but the compiler cannot automatically deduce this.
             assertDefined(
               assignedSuit,
               "Implementation error: Array access undefined after range check.",


### PR DESCRIPTION
This cleans up some of the Sudoku code as requested:
- Removes null-assertion operator, instead uses a combination of `assertDefined` and more specific types to ensure safe index access.
- Clarifies the suitMaxScores variable, which was confusing before
- Fix a bug in the sudoku score calculation:
    - If both copies of a 5 were discarded, this caused wrong calculations on the maximum possible score.
    - This bug was introduced 1bd3fc87, since previously, the iterated range might have been empty when `lastDead +1 > 5` (which happens when both copies of a 5 have been discarded, but the `iRange` macro that had been introduced returns a reverse range in this case.
    - In general, I think that this usage behaviour feels very dangeruous to me. While it is documented, i would expect something like `eRange(5,2)` to just be empty, since this is also the standard behaviour in languages like C++, Python, etc. As you have seen, you (James) yourself have misused the macro yielding to above bug.
    - In case we don't explicitly need this reverse range behaviour, I would suggest removing it. Otherwise, we should probably check all refactored such range expressions and whether similar bugs have been introduced elsewhere.