### PR TITLE
rename command: links -> linked

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -40,7 +40,7 @@ If you need general help with the website, then read the [features page](feature
 | `/friends`             | Show a list of all your friends             |
 | `/unfriend [username]` | Remove someone from your friends list       |
 | `/link [username]`     | Add someone to your linked accounts         |
-| `/links`               | Show a list of all your linked accounts     |
+| `/linked`              | Show a list of all your linked accounts     |
 | `/unlink [username]`   | Remove someone from your linked accounts    |
 | `/tagsearch [tag]`     | Search through all games for a specific tag |
 | `/version`             | Show the version number of the client code  |

--- a/packages/client/src/chatCommands.ts
+++ b/packages/client/src/chatCommands.ts
@@ -95,13 +95,14 @@ function unlink(room: string, args: readonly string[]) {
 }
 
 // /links
-function links() {
-  globals.conn!.send("chatLinks", {});
+function linked() {
+  globals.conn!.send("chatLinked", {});
 }
 
 chatCommands.set("link", link);
 chatCommands.set("unlink", unlink);
-chatCommands.set("links", links);
+chatCommands.set("linked", linked);
+chatCommands.set("links", linked);
 
 // /pm [username] [msg]
 function pm(room: string, args: readonly string[]) {

--- a/server/src/chat_command.go
+++ b/server/src/chat_command.go
@@ -61,7 +61,7 @@ func chatCommandInit() {
 	chatCommandMap["friends"] = chatCommandWebsiteOnly
 	chatCommandMap["unfriend"] = chatCommandWebsiteOnly
 	chatCommandMap["link"] = chatCommandWebsiteOnly
-	chatCommandMap["links"] = chatCommandWebsiteOnly
+	chatCommandMap["linked"] = chatCommandWebsiteOnly
 	chatCommandMap["unlink"] = chatCommandWebsiteOnly
 	chatCommandMap["version"] = chatCommandWebsiteOnly
 	chatCommandMap["terminate"] = chatCommandWebsiteOnly

--- a/server/src/command.go
+++ b/server/src/command.go
@@ -121,7 +121,7 @@ func commandInit() {
 	commandMap["chatUnfriend"] = commandChatUnfriend
 	commandMap["chatLink"] = commandChatLink
 	commandMap["chatUnlink"] = commandChatUnlink
-	commandMap["chatLinks"] = commandChatLinks
+	commandMap["chatLinked"] = commandChatLinked
 	commandMap["chatPlayerInfo"] = commandChatPlayerInfo
 	commandMap["getName"] = commandGetName
 	commandMap["inactive"] = commandInactive

--- a/server/src/command_chat_link.go
+++ b/server/src/command_chat_link.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func commandChatLinks(ctx context.Context, s *Session, d *CommandData) {
+func commandChatLinked(ctx context.Context, s *Session, d *CommandData) {
 	var usernames []string
 	if val, err := models.UserLinkages.GetAllLinkedUsernames(s.UserID); err != nil {
 		logger.Error("Failed to retrieve linked usernames for user " + s.Username)
@@ -38,7 +38,7 @@ func link(s *Session, d *CommandData, add bool) {
 	if len(d.Name) == 0 {
 		var msg string
 		if add {
-			msg = "The format of the /linked_user command is: /linked_user [username]"
+			msg = "The format of the /link command is: /link [username]"
 		} else {
 			msg = "The format of the /unlink command is: /unlink [username]"
 		}


### PR DESCRIPTION
People pointed out to me that this is probably the better naming. I'd suggest to keep /links as a (client-side) alias, so we'll just have both.