### PR TITLE
Bugix pm command: pass correct message

### DIFF
--- a/packages/client/src/chatCommands.ts
+++ b/packages/client/src/chatCommands.ts
@@ -139,7 +139,7 @@ function pm(room: string, args: readonly string[]) {
   }
 
   globals.conn!.send("chatPM", {
-    msg: args.join(" "),
+    msg: msg,
     recipient: matchingUser.name,
     room,
   });

--- a/packages/client/src/chatCommands.ts
+++ b/packages/client/src/chatCommands.ts
@@ -139,7 +139,7 @@ function pm(room: string, args: readonly string[]) {
   }
 
   globals.conn!.send("chatPM", {
-    msg: msg,
+    msg,
     recipient: matchingUser.name,
     room,
   });


### PR DESCRIPTION
When refactoring this was broken, doing `/pm Alice hi` results in `Alice hi` being written to Alice.