### PR TITLE
Bugfix: Total number of cards in Up or Down + Dark Suit

### DIFF
--- a/packages/client/src/game/rules/deck.ts
+++ b/packages/client/src/game/rules/deck.ts
@@ -19,6 +19,10 @@ export function totalCards(variant: Variant): number {
 
 function totalCardsInSuit(variant: Variant, suit: Suit): number {
   if (suit.oneOfEach) {
+    if (variant.upOrDown) {
+      // A critical suit in up or down has all unique cards plus an extra start card.
+      return variant.stackSize + 1;
+    }
     return variant.stackSize;
   }
 


### PR DESCRIPTION
Now that there is dark suits combined with Up or Down, we need to adapt the implementation to it, since there is now 6 cards of a dark suit in such a variant.

Since allowing this variant wasn't something I thought about a lot, I didn't think of it before. Also, there's nothing else I know about right now that we need to adapt about the rest of the code.