### PR TITLE
server: add stackSize to variants, refactoring

### DIFF
--- a/server/src/chat_pregame.go
+++ b/server/src/chat_pregame.go
@@ -239,14 +239,13 @@ func chatFindVariant(ctx context.Context, s *Session, d *CommandData, t *Table, 
 	// Make a list of variants that no-one has the max score in
 	variantsWithNoMaxScores := make([]string, 0)
 	for _, variant := range variants {
-		maxScore := len(variant.Suits) * PointsPerSuit
 		someoneHasMaxScore := false
 		for _, statsMap := range statsMaps {
 			if stats, ok := statsMap[variant.ID]; ok {
 				// This player has played at least one game in this particular variant
 				// Check to see if they have a max score
 				// We minus 2 because element 0 is for 2-player, element 1 is for 3-player, etc.
-				if stats.BestScores[len(userIDs)-2].Score == maxScore {
+				if stats.BestScores[len(userIDs)-2].Score == variant.MaxScore {
 					someoneHasMaxScore = true
 					break
 				}

--- a/server/src/constants.go
+++ b/server/src/constants.go
@@ -95,7 +95,7 @@ const (
 
 	// Currently, in all variants, you get 5 points per suit/stack,
 	// but this may not always be the case
-	PointsPerSuit = 5
+	DefaultPointsPerSuit = 5
 
 	DefaultVariantName = "No Variant"
 

--- a/server/src/game.go
+++ b/server/src/game.go
@@ -111,7 +111,7 @@ func NewGame(t *Table) *Game {
 		ActivePlayerIndex:     0,
 		ClueTokens:            variant.GetAdjustedClueTokens(MaxClueNum),
 		Score:                 0,
-		MaxScore:              len(variant.Suits) * PointsPerSuit,
+		MaxScore:              variant.MaxScore,
 		Strikes:               0,
 		LastClueTypeGiven:     -1,
 		Actions:               make([]interface{}, 0),

--- a/server/src/http_stats.go
+++ b/server/src/http_stats.go
@@ -97,7 +97,6 @@ func httpStats(c *gin.Context) {
 	variantStatsList := make([]*VariantStatsData, 0)
 	for _, name := range variantNames {
 		variant := variants[name]
-		maxScore := len(variant.Suits) * PointsPerSuit
 		variantStats := &VariantStatsData{ // nolint: exhaustivestruct
 			ID:   variant.ID,
 			Name: name,
@@ -106,7 +105,7 @@ func httpStats(c *gin.Context) {
 		if stats, ok := statsMap[variant.ID]; ok {
 			// Someone has played at least one game in this particular variant
 			for j, bestScore := range stats.BestScores {
-				if bestScore.Score == maxScore {
+				if bestScore.Score == variant.MaxScore {
 					numMaxScores++
 					numMaxScoresPerType[j]++
 				}

--- a/server/src/http_sub.go
+++ b/server/src/http_sub.go
@@ -114,17 +114,16 @@ func httpGetVariantStatsList(statsMap map[int]*UserStatsRow) (int, []int, []*Use
 	variantStatsList := make([]*UserVariantStats, 0)
 	for _, name := range variantNames {
 		variant := variants[name]
-		maxScore := len(variant.Suits) * PointsPerSuit
 		variantStats := &UserVariantStats{ // nolint: exhaustivestruct
 			ID:       variant.ID,
 			Name:     name,
-			MaxScore: maxScore,
+			MaxScore: variant.MaxScore,
 		}
 
 		if stats, ok := statsMap[variant.ID]; ok {
 			// This player has played at least one game in this particular variant
 			for j, bestScore := range stats.BestScores {
-				if bestScore.Score == maxScore {
+				if bestScore.Score == variant.MaxScore {
 					numMaxScores++
 					numMaxScoresPerType[j]++
 				}

--- a/server/src/variant.go
+++ b/server/src/variant.go
@@ -13,6 +13,7 @@ type Variant struct {
 	Ranks                    []int
 	ClueColors               []string
 	ClueRanks                []int
+	StackSize                int
 	ColorCluesTouchNothing   bool
 	RankCluesTouchNothing    bool
 	SpecialRank              int // For e.g. Rainbow-Ones

--- a/server/src/variants.go
+++ b/server/src/variants.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/Hanabi-Live/hanabi-live/logger"
 	"os"
 	"path"
 	"strconv"
-	"strings"
-
-	"github.com/Hanabi-Live/hanabi-live/logger"
 )
 
 var (
@@ -39,6 +37,8 @@ type VariantJSON struct {
 	OddsAndEvens             bool      `json:"oddsAndEvens"`
 	Funnels                  bool      `json:"funnels"`
 	Chimneys                 bool      `json:"chimneys"`
+	Sudoku                   bool      `json:"sudoku"`
+	UpOrDown                 bool      `json:"upOrDown"`
 }
 
 func variantsInit() {
@@ -99,13 +99,18 @@ func variantsInit() {
 		// Derive the card ranks (the ranks that the cards of each suit will be)
 		// By default, assume ranks 1 through 5
 		variantRanks := []int{1, 2, 3, 4, 5}
-		if strings.HasPrefix(variant.Name, "Sudoku") {
+		if variant.Sudoku {
 			variantRanks = variantRanks[:len(variantSuits)]
 		}
-		if strings.HasPrefix(variant.Name, "Up or Down") {
+		if variant.UpOrDown {
 			// The "Up or Down" variants have START cards
 			// ("startCardRank" is defined in the "variantUpOrDown.go" file)
 			variantRanks = append(variantRanks, StartCardRank)
+		}
+
+		stackSize := DefaultPointsPerSuit
+		if variant.Sudoku {
+			stackSize = len(variantSuits)
 		}
 
 		// Validate or derive the clue colors (the colors available to clue in this variant)
@@ -159,6 +164,7 @@ func variantsInit() {
 			Ranks:                    variantRanks,
 			ClueColors:               *clueColors,
 			ClueRanks:                *clueRanks,
+			StackSize:                stackSize,
 			ColorCluesTouchNothing:   variant.ColorCluesTouchNothing,
 			RankCluesTouchNothing:    variant.RankCluesTouchNothing,
 			SpecialRank:              specialRank,
@@ -170,7 +176,7 @@ func variantsInit() {
 			OddsAndEvens:             variant.OddsAndEvens,
 			Funnels:                  variant.Funnels,
 			Chimneys:                 variant.Chimneys,
-			MaxScore:                 len(variantSuits) * 5,
+			MaxScore:                 len(variantSuits) * stackSize,
 			// (we assume that there are 5 points per stack)
 		}
 

--- a/server/src/variants_reversible.go
+++ b/server/src/variants_reversible.go
@@ -113,7 +113,7 @@ func variantReversibleGetMaxScore(g *Game) int {
 		} else if g.PlayStackDirections[suitIndex] == StackDirectionDown {
 			maxScore += variantReversibleWalkDown(g, allDiscarded)
 		} else if g.PlayStackDirections[suitIndex] == StackDirectionFinished {
-			maxScore += 5
+			maxScore += variant.StackSize
 		}
 	}
 


### PR DESCRIPTION
Turns out the server did not have a sense of different stackSizes and therefore scores thus far, which is in particular why the stats page was bugged and it showed 20 for Sudoku 4 suits.

Variants already had a property `maxScore`, but it was not used consistently, I refactored (hopefully) all the usages to use `variant.maxScore` now when appropriate and set this value accordingly at initialization. Same goes for `stackSize`, which is added now as an additional attribute and used in the Sudoku code for more clarity.

I did a test game locally and it shows Sudoku correctly now on the stats page, the checkmark also works.