### PR TITLE
SLR: Clean up Sudoku code

### DIFF
--- a/packages/game/src/rules/variants/sudoku.ts
+++ b/packages/game/src/rules/variants/sudoku.ts
@@ -70,8 +70,8 @@ export function sudokuWalkUpAll(
     if (allDiscardedSet.has(currentRank)) {
       // We hit a new dead rank.
       for (const writeRank of eRange(lastDead + 1, currentRank)) {
-        maxScoresForEachStartingValueOfSuit[writeRank - 1] =
-          currentRank - writeRank;
+        const maxScore = currentRank - writeRank;
+        maxScoresForEachStartingValueOfSuit[writeRank - 1] = maxScore;
       }
 
       maxScoresForEachStartingValueOfSuit[currentRank - 1] = 0;
@@ -95,10 +95,8 @@ export function sudokuWalkUpAll(
       const scoreForPlayingUpToLargestRank = variant.stackSize + 1 - writeRank;
       const scoreWithWraparound =
         scoreForStartingAt1 + scoreForPlayingUpToLargestRank;
-      maxScoresForEachStartingValueOfSuit[writeRank - 1] = Math.min(
-        scoreWithWraparound,
-        variant.stackSize,
-      );
+      const maxScore = Math.min(scoreWithWraparound, variant.stackSize);
+      maxScoresForEachStartingValueOfSuit[writeRank - 1] = maxScore;
     }
   }
 

--- a/packages/game/src/rules/variants/sudoku.ts
+++ b/packages/game/src/rules/variants/sudoku.ts
@@ -1,5 +1,4 @@
 import type { NumSuits, Rank, SuitIndex, Variant } from "@hanabi/data";
-import { DEFAULT_CARD_RANKS } from "@hanabi/data";
 import type { Tuple } from "isaacscript-common-ts";
 import { assertDefined, eRange, iRange, newArray } from "isaacscript-common-ts";
 import type { CardState } from "../../interfaces/CardState";
@@ -71,8 +70,8 @@ export function sudokuWalkUpAll(
     if (allDiscardedSet.has(currentRank)) {
       // We hit a new dead rank.
       for (const writeRank of eRange(lastDead + 1, currentRank)) {
-        const maxScore = currentRank - writeRank;
-        maxScoresForEachStartingValueOfSuit[writeRank - 1] = maxScore;
+        maxScoresForEachStartingValueOfSuit[writeRank - 1] =
+          currentRank - writeRank;
       }
 
       maxScoresForEachStartingValueOfSuit[currentRank - 1] = 0;
@@ -92,15 +91,14 @@ export function sudokuWalkUpAll(
     // Here, we still need to write all "higher" values, adding the longest sequence starting at 1
     // to them.
     for (const writeRank of iRange(lastDead + 1, variant.stackSize)) {
-      const maxScore = Math.min(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        maxScoresForEachStartingValueOfSuit[0]! +
-          variant.stackSize +
-          1 -
-          writeRank,
-        DEFAULT_CARD_RANKS.length,
+      const scoreForStartingAt1 = maxScoresForEachStartingValueOfSuit[0];
+      const scoreForPlayingUpToLargestRank = variant.stackSize + 1 - writeRank;
+      const scoreWithWraparound =
+        scoreForStartingAt1 + scoreForPlayingUpToLargestRank;
+      maxScoresForEachStartingValueOfSuit[writeRank - 1] = Math.min(
+        scoreWithWraparound,
+        variant.stackSize,
       );
-      maxScoresForEachStartingValueOfSuit[writeRank - 1] = maxScore;
     }
   }
 


### PR DESCRIPTION
This also fixes a bug: In Sudoku 4-suit, the minimum should be taken with variant.stackSize, not with just the default number of suits.