### PR TITLE
fix parsing colors in hypos

### DIFF
--- a/packages/client/src/lobby/createReplayJSON.ts
+++ b/packages/client/src/lobby/createReplayJSON.ts
@@ -375,8 +375,8 @@ function getColorIndexFromColorName(
   colorName: string,
   variant: Variant,
 ): ColorIndex | undefined {
-  const colorIndex = variant.clueColors.findIndex(
-    (clueColor) => clueColor.name === colorName,
+  const colorIndex = variant.clueColors.findIndex((clueColor) =>
+    colorName.startsWith(clueColor.name),
   );
 
   return colorIndex === -1 ? undefined : (colorIndex as ColorIndex);


### PR DESCRIPTION
This fixes the bug introduced in ad384ac during refactoring, where the `startsWith` method was replaced with an exact match.