### PR TITLE
Make PMs received during games display a chat notification in the bottom left

### DIFF
--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -44,11 +44,16 @@ commands.set("error", (data: ServerCommandErrorData) => {
 // Received by the client when a new chat message arrives.
 commands.set("chat", (data: ServerCommandChatData) => {
   chat.add(data, false); // The second argument is "fast".
-  acknowledgeChatRead(data.room);
+  acknowledgeChatRead(data.room, data.recipient);
 });
 
-function acknowledgeChatRead(room: string | undefined) {
-  if (room === undefined || !room.startsWith("table")) {
+function acknowledgeChatRead(
+  room: string | undefined,
+  recipient: string | undefined,
+) {
+  const isPM = recipient !== undefined && recipient !== "";
+  const isTableRoom = room !== undefined && room.startsWith("table");
+  if (!isPM && !isTableRoom) {
     return;
   }
 

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -53,7 +53,8 @@ function acknowledgeChatRead(
 ) {
   const isPM = recipient !== undefined && recipient !== "";
   const isTableRoom = room !== undefined && room.startsWith("table");
-  if (!isPM && !isTableRoom) {
+  const isLobbyChat = !isPM && !isTableRoom;
+  if (isLobbyChat) {
     return;
   }
 


### PR DESCRIPTION
should resolve #2940 

Tested locally:
receiving a pm in game -> now the number shows up next to the chat icon
receiving a normal in game message -> still get a number showing up
receiving a normal message and pm in global lobby -> no errors in console