### PR TITLE
Join pre-game with stored join password

### DIFF
--- a/packages/client/src/lobby/url.ts
+++ b/packages/client/src/lobby/url.ts
@@ -61,6 +61,8 @@ export function parseAndGoto(data: ServerCommandWelcomeData): void {
     if (tableIDString !== undefined) {
       const tableID = parseIntSafe(tableIDString);
       if (tableID !== undefined && tableID > 0) {
+        // Here we unconditionally send password from cookies. If the game has no password, the
+        // server will ignore it.
         const password = localStorage.getItem("joinTablePassword");
         globals.conn!.send("tableJoin", {
           tableID,

--- a/packages/client/src/lobby/url.ts
+++ b/packages/client/src/lobby/url.ts
@@ -61,8 +61,10 @@ export function parseAndGoto(data: ServerCommandWelcomeData): void {
     if (tableIDString !== undefined) {
       const tableID = parseIntSafe(tableIDString);
       if (tableID !== undefined && tableID > 0) {
+        const password = localStorage.getItem("joinTablePassword");
         globals.conn!.send("tableJoin", {
           tableID,
+          password
         });
         return;
       }

--- a/packages/client/src/lobby/url.ts
+++ b/packages/client/src/lobby/url.ts
@@ -64,7 +64,7 @@ export function parseAndGoto(data: ServerCommandWelcomeData): void {
         const password = localStorage.getItem("joinTablePassword");
         globals.conn!.send("tableJoin", {
           tableID,
-          password
+          password,
         });
         return;
       }


### PR DESCRIPTION
When pre-game url is opened - send join request with stored join password.

I play hanabi mostly with my friends on password
protected tables. Every time I open the pre-game link, It tells me: "That is not the correct password for the game". I didn't provide any password, yet. But the game gives me an error message.

This PR fixes my use case, and doesn't break games without passords Tested this way (U1, U2 - users):
1. U1: Create game without password.
2. U2: Join the pre-game link
3. U1, U2 leave table
4. U1: Create password protected game
5. U2: Join the pre-game link. Notice the wrong password message
6. U2: Enters password, successfully joins the table
6. U1, U2 leave game
7. U1: Create password proteced game. (Same password)
8. U2: Join the pre-game link. **No errors**
9. U1, U2 leave game
10. U1 crate game without password
11. U2 Join the pre-game link. No errors (the stored password is still sent because of this PR)