### PR TITLE
Add hanabi.wiki to the list of resources

### DIFF
--- a/packages/server/src/templates/main.eta
+++ b/packages/server/src/templates/main.eta
@@ -1428,7 +1428,7 @@
           target="_blank"
           rel="noopener noreferrer"
         >
-          The H-group Discord Server </a
+          The H-Group Discord Server </a
         ><br />
         A place to find teammates and discuss strategy.
       </li>

--- a/packages/server/src/templates/main.eta
+++ b/packages/server/src/templates/main.eta
@@ -1450,7 +1450,7 @@
           target="_blank"
           rel="noopener noreferrer"
         >
-          Hanabi Central wiki </a
+          Hanabi Central Wiki </a
         ><br />
         This wiki contains even more convention systems.
       </li>

--- a/packages/server/src/templates/main.eta
+++ b/packages/server/src/templates/main.eta
@@ -1428,7 +1428,7 @@
           target="_blank"
           rel="noopener noreferrer"
         >
-          The Discord Server </a
+          The H-group Discord Server </a
         ><br />
         A place to find teammates and discuss strategy.
       </li>
@@ -1443,6 +1443,16 @@
         This is a document that lists the strategies and conventions used by
         the H-Group.<br />
         (You don't have to use them if you don't want to.)
+      </li>
+      <li>
+        <a
+          href="https://hanabi.wiki/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Hanabi Central wiki </a
+        ><br />
+        This wiki contains even more convention systems.
       </li>
       <li>
         <a

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -1449,7 +1449,7 @@
             target="_blank"
             rel="noopener noreferrer"
           >
-            Hanabi Central wiki </a
+            Hanabi Central Wiki </a
           ><br />
           This wiki contains even more convention systems.
         </li>        

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -1427,7 +1427,7 @@
             target="_blank"
             rel="noopener noreferrer"
           >
-            The H-group Discord Server </a
+            The H-Group Discord Server </a
           ><br />
           A place to find teammates and discuss strategy.
         </li>

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -1452,7 +1452,7 @@
             Hanabi Central Wiki </a
           ><br />
           This wiki contains even more convention systems.
-        </li>        
+        </li>
         <li>
           <a
             href="https://github.com/Hanabi-Live/hanabi-live"

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -1427,7 +1427,7 @@
             target="_blank"
             rel="noopener noreferrer"
           >
-            The Discord Server </a
+            The H-group Discord Server </a
           ><br />
           A place to find teammates and discuss strategy.
         </li>

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -1445,6 +1445,16 @@
         </li>
         <li>
           <a
+            href="https://hanabi.wiki/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Hanabi Central wiki </a
+          ><br />
+          This wiki contains even more convention systems.
+        </li>        
+        <li>
+          <a
             href="https://github.com/Hanabi-Live/hanabi-live"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
After players learn H-group, a good number are also interested in H-group spinoffs and other convention systems. And some of those curious will check out the list of resources too, so I suggest including hanabi.wiki as well.