### PR TITLE
fix: correct player cycling logic in Tab key shortcut

### DIFF
--- a/packages/client/src/game/ui/ButtonGroup.ts
+++ b/packages/client/src/game/ui/ButtonGroup.ts
@@ -67,22 +67,21 @@ export class ButtonGroup extends Konva.Group {
       buttonIndex = -1;
     }
 
-    // Find the next button in the group. As a guard against an infinite loop, only loop as many
-    // times as needed to go through every button.
+    // Find the next enabled button in the group.
+    const total = this.list.length;
     let nextButton: ClueButton | undefined;
-    for (const clueButton of this.list) {
-      buttonIndex++;
-      if (buttonIndex > this.list.length - 1) {
-        buttonIndex = 0;
-      }
 
-      nextButton = clueButton;
-      if ("enabled" in nextButton && nextButton.enabled) {
+    for (let i = 1; i <= total; i++) {
+      const candidateIndex = (buttonIndex + i) % total;
+      const candidate = this.list[candidateIndex];
+
+      if (candidate && "enabled" in candidate && candidate.enabled) {
+        nextButton = candidate;
         break;
       }
     }
 
-    if (nextButton !== undefined) {
+    if (nextButton) {
       nextButton.dispatchEvent(new MouseEvent("click"));
     }
   }

--- a/packages/client/src/game/ui/ButtonGroup.ts
+++ b/packages/client/src/game/ui/ButtonGroup.ts
@@ -72,15 +72,19 @@ export class ButtonGroup extends Konva.Group {
 
     for (let i = 1; i <= total; i++) {
       const candidateIndex = (buttonIndex + i) % total;
-      const candidate = this.list[candidateIndex];
+      const candidateButton = this.list[candidateIndex];
 
-      if (candidate && "enabled" in candidate && candidate.enabled) {
-        nextButton = candidate;
+      if (
+        candidateButton !== undefined &&
+        "enabled" in candidateButton &&
+        candidateButton.enabled
+      ) {
+        nextButton = candidateButton;
         break;
       }
     }
 
-    if (nextButton) {
+    if (nextButton !== undefined) {
       nextButton.dispatchEvent(new MouseEvent("click"));
     }
   }

--- a/packages/client/src/game/ui/ButtonGroup.ts
+++ b/packages/client/src/game/ui/ButtonGroup.ts
@@ -46,6 +46,16 @@ export class ButtonGroup extends Konva.Group {
     return null;
   }
 
+  getPressedIndex(): number | null {
+    for (const [i, button] of this.list.entries()) {
+      if (button.pressed) {
+        return i;
+      }
+    }
+
+    return null;
+  }
+
   clearPressed(): void {
     for (const clueButton of this.list) {
       clueButton.setPressed(false);
@@ -54,18 +64,7 @@ export class ButtonGroup extends Konva.Group {
 
   /** This is only used for groups of "PlayerButton". */
   selectNextTarget(): void {
-    let buttonIndex: number | undefined;
-    for (const [i, clueButton] of this.list.entries()) {
-      if (clueButton.pressed) {
-        buttonIndex = i;
-        break;
-      }
-    }
-
-    // It is possible that no buttons are currently pressed.
-    if (buttonIndex === undefined) {
-      buttonIndex = -1;
-    }
+    const buttonIndex = this.getPressedIndex() ?? -1;
 
     // Find the next enabled button in the group.
     const total = this.list.length;


### PR DESCRIPTION
The selectNextTarget() function had a logical bug where it was using a for...of loop while incrementing a separate buttonIndex variable, causing it to skip buttons and fail to cycle properly through players.

Fixed by replacing the flawed loop with a for loop using modulo arithmetic:
- Uses (buttonIndex + i) % total pattern for circular iteration
- Properly cycles through all button indices in order
- Only selects enabled buttons

This resolves the issue where Tab key player cycling would only work once or sporadically instead of cycling through all available players.